### PR TITLE
apps/sample-vue-full: fully revamp to new design with Ant Design

### DIFF
--- a/apps/sample-vue-full/components/ChartCard.vue
+++ b/apps/sample-vue-full/components/ChartCard.vue
@@ -1,0 +1,103 @@
+<template>
+  <a-card :bordered="false" class="chart-card">
+    <template #title>
+      <div class="card-title-row">
+        <component :is="titleIcon" v-if="titleIcon" class="card-title-icon" />
+        <span>{{ title }}</span>
+      </div>
+    </template>
+
+    <template v-if="$slots.extra" #extra>
+      <slot name="extra" />
+    </template>
+
+    <div class="chart-wrapper" :style="{ height: `${height}px` }">
+      <canvas ref="canvasRef" />
+    </div>
+  </a-card>
+</template>
+
+<script setup>
+import Chart from 'chart.js/auto';
+import { onMounted, onUnmounted, ref, watch } from 'vue';
+
+const props = defineProps({
+  title: { type: String, default: 'Chart' },
+  titleIcon: { type: Object, default: null },
+  chartType: { type: String, default: 'bar' },
+  labels: { type: Array, required: true },
+  datasets: { type: Array, required: true },
+  height: { type: Number, default: 240 },
+  options: { type: Object, default: () => ({}) },
+});
+
+const canvasRef = ref(null);
+let chartInstance = null;
+
+const buildChart = () => {
+  if (chartInstance) chartInstance.destroy();
+  if (!canvasRef.value) return;
+
+  chartInstance = new Chart(canvasRef.value, {
+    type: props.chartType,
+    data: { labels: props.labels, datasets: props.datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { position: 'bottom' } },
+      ...props.options,
+    },
+  });
+};
+
+onMounted(buildChart);
+onUnmounted(() => {
+  if (chartInstance) chartInstance.destroy();
+});
+
+watch(
+  () => [props.labels, props.datasets, props.chartType],
+  () => {
+    buildChart();
+  },
+  { deep: true },
+);
+</script>
+
+<style scoped>
+.chart-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  height: 100%;
+}
+
+:deep(.chart-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.chart-card .ant-card-body) {
+  padding: 16px 20px 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+.chart-wrapper {
+  position: relative;
+  width: 100%;
+}
+</style>

--- a/apps/sample-vue-full/components/ColorBox.vue
+++ b/apps/sample-vue-full/components/ColorBox.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="color-box" :style="{ backgroundColor: color }">
+    <span class="color-box-label">{{ label }}</span>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  color: { type: String, required: true },
+  label: { type: String, required: true },
+});
+</script>
+
+<style scoped>
+.color-box {
+  width: 80px;
+  height: 80px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  flex-shrink: 0;
+}
+
+.color-box:hover {
+  transform: translateY(-3px) scale(1.05);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
+}
+
+.color-box-label {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+</style>

--- a/apps/sample-vue-full/components/LeafletMap.vue
+++ b/apps/sample-vue-full/components/LeafletMap.vue
@@ -46,9 +46,8 @@ const addMarkers = () => {
   markerInstances.length = 0;
 
   for (const loc of props.markers) {
-    const m = L.marker([loc.lat, loc.lng])
-      .addTo(mapInstance)
-      .bindPopup(`<strong>${loc.title}</strong>${loc.desc ? `<br>${loc.desc}` : ''}`);
+    const descHtml = loc.desc ? `<br>${loc.desc}` : '';
+    const m = L.marker([loc.lat, loc.lng]).addTo(mapInstance).bindPopup(`<strong>${loc.title}</strong>${descHtml}`);
 
     m.on('click', () => emit('marker-click', loc));
     markerInstances.push(m);

--- a/apps/sample-vue-full/components/LeafletMap.vue
+++ b/apps/sample-vue-full/components/LeafletMap.vue
@@ -1,0 +1,108 @@
+<template>
+  <div ref="mapRef" class="leaflet-map-container" />
+</template>
+
+<script setup>
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+import { onMounted, onUnmounted, ref, watch } from 'vue';
+
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({ iconUrl: markerIcon, iconRetinaUrl: markerIcon2x, shadowUrl: markerShadow });
+
+const props = defineProps({
+  center: { type: Array, default: () => [51.505, -0.09] },
+  zoom: { type: Number, default: 13 },
+  markers: { type: Array, default: () => [] },
+  tileLayer: { type: String, default: 'osm' },
+});
+
+const emit = defineEmits(['map-click', 'marker-click']);
+
+const mapRef = ref(null);
+let mapInstance = null;
+const markerInstances = [];
+
+const tileLayers = {
+  osm: {
+    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  },
+  topo: {
+    url: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
+    attribution: '&copy; <a href="https://opentopomap.org">OpenTopoMap</a> contributors',
+  },
+  dark: {
+    url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
+    attribution: '&copy; <a href="https://carto.com/">CARTO</a>',
+  },
+};
+
+const addMarkers = () => {
+  for (const m of markerInstances) m.remove();
+  markerInstances.length = 0;
+
+  for (const loc of props.markers) {
+    const m = L.marker([loc.lat, loc.lng])
+      .addTo(mapInstance)
+      .bindPopup(`<strong>${loc.title}</strong>${loc.desc ? `<br>${loc.desc}` : ''}`);
+
+    m.on('click', () => emit('marker-click', loc));
+    markerInstances.push(m);
+  }
+};
+
+onMounted(() => {
+  mapInstance = L.map(mapRef.value).setView(props.center, props.zoom);
+
+  const layer = tileLayers[props.tileLayer] ?? tileLayers.osm;
+  L.tileLayer(layer.url, { attribution: layer.attribution }).addTo(mapInstance);
+
+  mapInstance.on('click', e => emit('map-click', { lat: e.latlng.lat, lng: e.latlng.lng }));
+
+  addMarkers();
+});
+
+onUnmounted(() => {
+  if (mapInstance) mapInstance.remove();
+});
+
+watch(() => props.markers, addMarkers, { deep: true });
+
+watch(
+  () => props.tileLayer,
+  val => {
+    if (!mapInstance) return;
+    mapInstance.eachLayer(l => {
+      if (l instanceof L.TileLayer) mapInstance.removeLayer(l);
+    });
+    const layer = tileLayers[val] ?? tileLayers.osm;
+    L.tileLayer(layer.url, { attribution: layer.attribution }).addTo(mapInstance);
+  },
+);
+
+watch(
+  () => props.center,
+  val => {
+    if (mapInstance) mapInstance.setView(val, props.zoom);
+  },
+);
+
+defineExpose({
+  flyTo: (lat, lng, zoom) => mapInstance?.flyTo([lat, lng], zoom ?? props.zoom),
+});
+</script>
+
+<style scoped>
+.leaflet-map-container {
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  border-radius: 10px;
+  overflow: hidden;
+  z-index: 1;
+}
+</style>

--- a/apps/sample-vue-full/components/SignaturePad.vue
+++ b/apps/sample-vue-full/components/SignaturePad.vue
@@ -1,0 +1,194 @@
+<template>
+  <a-card :bordered="false" class="signpad-card">
+    <template #title>
+      <div class="card-title-row">
+        <EditOutlined class="card-title-icon" />
+        <span>{{ title }}</span>
+      </div>
+    </template>
+
+    <template #extra>
+      <a-tag :color="isSigned ? 'green' : 'default'">
+        {{ isSigned ? 'Signed' : 'Empty' }}
+      </a-tag>
+    </template>
+
+    <!-- Web component -->
+    <div class="pad-wrapper">
+      <p class="pad-hint">Draw your signature below</p>
+      <vcxwc-sign-pad
+        :width="width"
+        :height="height"
+        :value="modelValue"
+        :context2d="context2dJson"
+        :style="{ '--vcxwc-sign-pad-background-color': backgroundColor }"
+        class="sign-pad-el"
+        @input="onInput"
+      />
+    </div>
+
+    <!-- Actions -->
+    <div class="pad-actions">
+      <a-button
+        :disabled="!isSigned"
+        type="primary"
+        size="small"
+        @click="download"
+      >
+        <template #icon><DownloadOutlined /></template>
+        Save
+      </a-button>
+
+      <a-button
+        :disabled="!isSigned"
+        size="small"
+        danger
+        @click="clear"
+      >
+        <template #icon><DeleteOutlined /></template>
+        Clear
+      </a-button>
+    </div>
+
+    <!-- Preview -->
+    <Transition name="preview-fade">
+      <div v-if="isSigned" class="pad-preview">
+        <a-divider orientation="left" style="font-size:13px">Preview</a-divider>
+        <a-image
+          :src="modelValue"
+          :width="width"
+          :height="height"
+          :preview="{ mask: 'Enlarge' }"
+          class="preview-img"
+        />
+      </div>
+    </Transition>
+  </a-card>
+</template>
+
+<script setup>
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
+import { DeleteOutlined, DownloadOutlined, EditOutlined } from '@ant-design/icons-vue';
+import { computed } from 'vue';
+import '@common/web/sign-pad.js';
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  title: { type: String, default: 'Signature Pad' },
+  width: { type: Number, default: 300 },
+  height: { type: Number, default: 150 },
+  lineWidth: { type: Number, default: 2 },
+  strokeStyle: { type: String, default: '#1e293b' },
+  backgroundColor: { type: String, default: '#f8fafc' },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const context2dJson = computed(() => JSON.stringify({ lineWidth: props.lineWidth, strokeStyle: props.strokeStyle }));
+
+const isSigned = computed(() => !!props.modelValue);
+
+const onInput = e => {
+  emit('update:modelValue', e.target.value ?? '');
+};
+
+const clear = () => {
+  emit('update:modelValue', '');
+};
+
+const download = () => {
+  const a = document.createElement('a');
+  a.href = props.modelValue;
+  a.download = 'signature.png';
+  a.click();
+};
+</script>
+
+<style scoped>
+.signpad-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+:deep(.signpad-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.signpad-card .ant-card-body) {
+  padding: 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+/* Pad area */
+.pad-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pad-hint {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  color: #64748b;
+  margin: 0;
+}
+
+.sign-pad-el {
+  border: 2px dashed #cbd5e1;
+  border-radius: 10px;
+  overflow: hidden;
+  display: block;
+  cursor: crosshair;
+  transition: border-color 0.2s;
+}
+
+.sign-pad-el:hover {
+  border-color: #4f46e5;
+}
+
+/* Actions */
+.pad-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+/* Preview */
+.pad-preview {
+  margin-top: 4px;
+}
+
+:deep(.preview-img.ant-image img) {
+  border-radius: 8px;
+  border: 1.5px solid #e2e8f0;
+  object-fit: contain;
+}
+
+/* Transitions */
+.preview-fade-enter-active,
+.preview-fade-leave-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.preview-fade-enter-from,
+.preview-fade-leave-to {
+  opacity: 0;
+  transform: translateY(8px);
+}
+</style>

--- a/apps/sample-vue-full/components/WebCamCapture.vue
+++ b/apps/sample-vue-full/components/WebCamCapture.vue
@@ -1,0 +1,274 @@
+<template>
+  <a-card :bordered="false" class="webcam-card">
+    <template #title>
+      <div class="card-title-row">
+        <VideoCameraOutlined class="card-title-icon" />
+        <span>{{ title }}</span>
+      </div>
+    </template>
+
+    <template #extra>
+      <a-tag :color="isActive ? 'green' : 'default'" class="status-tag">
+        <template #icon>
+          <span class="status-dot" :class="{ 'status-dot--active': isActive }" />
+        </template>
+        {{ isActive ? 'Live' : 'Standby' }}
+      </a-tag>
+    </template>
+
+    <!-- Web component — CSS custom properties control button position inside shadow DOM -->
+    <div class="webcam-wrapper">
+      <vcxwc-web-cam
+        :width="width"
+        :height="height"
+        style="--vcxwc-web-cam-top: 8%"
+        @snap="onSnap"
+      >
+        <button
+          slot="button-snap"
+          type="button"
+          class="cam-btn cam-btn--snap"
+          @click="isActive = true"
+        >
+          📷 Take Photo
+        </button>
+        <button
+          slot="button-unsnap"
+          type="button"
+          class="cam-btn cam-btn--unsnap"
+          @click="isActive = true"
+        >
+          🎥 Start Camera
+        </button>
+      </vcxwc-web-cam>
+    </div>
+
+    <!-- Snapshot preview -->
+    <Transition name="snap-fade">
+      <div v-if="snapshots.length" class="snapshot-section">
+        <a-divider orientation="left" style="font-size:13px">
+          Captured ({{ snapshots.length }})
+        </a-divider>
+
+        <div class="snapshot-grid">
+          <div
+            v-for="(snap, i) in snapshots"
+            :key="i"
+            class="snapshot-item"
+          >
+            <a-image
+              :src="snap"
+              :width="120"
+              :height="90"
+              :preview="{ mask: 'Preview' }"
+              class="snapshot-img"
+            />
+            <div class="snapshot-actions">
+              <a-button type="text" size="small" @click="download(snap, i)">
+                <template #icon><DownloadOutlined /></template>
+              </a-button>
+              <a-button type="text" size="small" danger @click="remove(i)">
+                <template #icon><DeleteOutlined /></template>
+              </a-button>
+            </div>
+          </div>
+        </div>
+
+        <a-button
+          v-if="snapshots.length > 1"
+          type="default"
+          size="small"
+          danger
+          style="margin-top: 8px"
+          @click="snapshots = []"
+        >
+          <template #icon><DeleteOutlined /></template>
+          Clear All
+        </a-button>
+      </div>
+    </Transition>
+  </a-card>
+</template>
+
+<script setup>
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
+import { DeleteOutlined, DownloadOutlined, VideoCameraOutlined } from '@ant-design/icons-vue';
+import { ref } from 'vue';
+import '@common/web/web-cam.js';
+
+const props = defineProps({
+  title: { type: String, default: 'Web Camera' },
+  width: { type: Number, default: 320 },
+  height: { type: Number, default: 240 },
+});
+
+const emit = defineEmits(['snap']);
+
+const isActive = ref(false);
+const snapshots = ref([]);
+
+const onSnap = e => {
+  const dataUrl = e.detail;
+  snapshots.value.unshift(dataUrl);
+  emit('snap', dataUrl);
+};
+
+const download = (dataUrl, index) => {
+  const a = document.createElement('a');
+  a.href = dataUrl;
+  a.download = `photo-${index + 1}.png`;
+  a.click();
+};
+
+const remove = index => {
+  snapshots.value.splice(index, 1);
+};
+</script>
+
+<style scoped>
+.webcam-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+:deep(.webcam-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.webcam-card .ant-card-body) {
+  padding: 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+/* Status indicator */
+.status-tag {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #cbd5e1;
+}
+
+.status-dot--active {
+  background: #16a34a;
+  box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.2);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* Web component wrapper */
+.webcam-wrapper {
+  position: relative;
+  display: inline-block;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 2px solid #e2e8f0;
+}
+
+/* Slotted button styles — positioning is handled by shadow DOM's ::slotted(button)
+   via --vcxwc-web-cam-top CSS custom property; only appearance is set here */
+.cam-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 12px;
+  border: none;
+  border-radius: 6px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, transform 0.1s;
+}
+
+.cam-btn--snap {
+  background: #4f46e5;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(79, 70, 229, 0.35);
+}
+
+.cam-btn--snap:hover {
+  background: #4338ca;
+  transform: scale(1.03);
+}
+
+.cam-btn--unsnap {
+  background: rgba(255, 255, 255, 0.9);
+  color: #1e293b;
+  border: 1.5px solid #e2e8f0;
+}
+
+.cam-btn--unsnap:hover {
+  background: #f1f5f9;
+  transform: scale(1.03);
+}
+
+/* Snapshot section */
+.snapshot-section {
+  margin-top: 16px;
+}
+
+.snapshot-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.snapshot-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+:deep(.snapshot-img.ant-image img) {
+  border-radius: 8px;
+  object-fit: cover;
+  border: 1.5px solid #e2e8f0;
+}
+
+.snapshot-actions {
+  display: flex;
+  gap: 4px;
+}
+
+/* Transition */
+.snap-fade-enter-active,
+.snap-fade-leave-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.snap-fade-enter-from,
+.snap-fade-leave-to {
+  opacity: 0;
+  transform: translateY(8px);
+}
+</style>

--- a/apps/sample-vue-full/mocks/handlers.js
+++ b/apps/sample-vue-full/mocks/handlers.js
@@ -1,29 +1,273 @@
 import { HttpResponse, http } from 'msw';
 
+const T4T_CONFIGS = {
+  student: {
+    conn: 'knex1',
+    name: 'student',
+    displayName: 'Students',
+    view: 'admin,editor,viewer',
+    update: 'admin,editor',
+    create: 'admin',
+    delete: 'admin',
+    deleteLimit: 1,
+    import: 'admin,editor',
+    export: 'admin,editor',
+    multiSelect: false,
+    cols: {
+      id: { label: 'ID', auto: 'pk', edit: 'readonly' },
+      firstName: {
+        label: 'First Name',
+        filter: true,
+        sort: true,
+        required: true,
+        add: true,
+        edit: true,
+        type: 'string',
+        ui: { tag: 'input', attrs: { type: 'text' } },
+      },
+      lastName: {
+        label: 'Last Name',
+        required: true,
+        add: true,
+        edit: true,
+        type: 'string',
+        filter: true,
+        ui: { tag: 'input', attrs: { type: 'text' } },
+      },
+      sex: {
+        label: 'Sex',
+        type: 'string',
+        filter: true,
+        add: true,
+        edit: true,
+        default: 'M',
+        ui: {
+          tag: 'select',
+          attrs: {
+            multiple: false,
+            options: [
+              { label: '', value: '' },
+              { label: 'Male', value: 'M' },
+              { label: 'Female', value: 'F' },
+            ],
+          },
+        },
+      },
+      age: {
+        label: 'Age',
+        type: 'integer',
+        filter: true,
+        add: true,
+        edit: true,
+        ui: { tag: 'input', attrs: { type: 'number', min: 10, max: 90, step: 1 } },
+      },
+      gpa: {
+        label: 'GPA',
+        type: 'decimal',
+        filter: true,
+        add: true,
+        edit: true,
+        ui: { tag: 'input', attrs: { type: 'number' } },
+      },
+      birthDate: {
+        label: 'Date of Birth',
+        type: 'string',
+        filter: true,
+        add: true,
+        edit: true,
+        ui: { tag: 'input', attrs: { type: 'date' } },
+      },
+      remarks: { label: 'Remarks', type: 'string', add: true, edit: true, ui: { tag: 'textarea', attrs: { rows: 4 } } },
+      updated_at: {
+        label: 'Updated At',
+        filter: true,
+        auto: 'ts',
+        edit: 'readonly',
+        type: 'datetime',
+        ui: { tag: 'input', attrs: { type: 'text' } },
+      },
+    },
+  },
+  subject: {
+    conn: 'knex1',
+    name: 'subject',
+    displayName: 'Subjects',
+    view: 'admin,editor,viewer',
+    update: 'admin,editor',
+    create: 'admin',
+    delete: 'admin',
+    deleteLimit: 2,
+    import: 'admin,editor',
+    export: 'admin,editor',
+    multiSelect: true,
+    cols: {
+      code: {
+        label: 'Code',
+        multiKey: true,
+        add: true,
+        edit: 'readonly',
+        type: 'string',
+        ui: { tag: 'input', attrs: { type: 'text' } },
+      },
+      name: {
+        label: 'Name',
+        multiKey: true,
+        add: true,
+        edit: true,
+        type: 'string',
+        ui: { tag: 'input', attrs: { type: 'text' } },
+      },
+      passingGrade: {
+        label: 'Passing Grade',
+        add: true,
+        edit: true,
+        required: true,
+        default: 50,
+        type: 'integer',
+        ui: { tag: 'input', attrs: { type: 'number', min: 1, max: 100, step: 1 } },
+      },
+    },
+  },
+  t4t_audit_logs: {
+    conn: 'knex1',
+    name: 'audit_logs',
+    displayName: 'Audit Logs',
+    view: 'admin,editor,viewer',
+    update: null,
+    create: null,
+    delete: null,
+    deleteLimit: -1,
+    import: null,
+    export: 'admin,editor',
+    multiSelect: false,
+    cols: {
+      id: { label: 'ID', auto: 'pk', hide: true, add: 'hide', edit: 'readonly' },
+      user: { label: 'User', type: 'string', ui: { tag: 'input' } },
+      timestamp: {
+        label: 'Timestamp',
+        filter: true,
+        type: 'datetime',
+        ui: { tag: 'input', attrs: { type: 'datetime-local' } },
+      },
+      db_name: { label: 'DB Name', filter: true, type: 'string', ui: { tag: 'input' } },
+      table_name: { label: 'Table Name', type: 'string', ui: { tag: 'input' } },
+      op: { label: 'Operation', type: 'string', ui: { tag: 'input' } },
+      cols_changed: { label: 'Cols Changed', type: 'string', ui: { tag: 'input' } },
+      new_values: { label: 'New Vals', type: 'string', ui: { tag: 'input' } },
+    },
+  },
+};
+
+const T4T_DATA = {
+  student: {
+    results: [
+      {
+        __key: '1',
+        id: 1,
+        firstName: 'Alice',
+        lastName: 'Smith',
+        sex: 'F',
+        age: 20,
+        gpa: 3.8,
+        birthDate: '2004-03-15',
+        remarks: '',
+        updated_at: '2025-01-10T08:00:00Z',
+      },
+      {
+        __key: '2',
+        id: 2,
+        firstName: 'Bob',
+        lastName: 'Jones',
+        sex: 'M',
+        age: 22,
+        gpa: 3.2,
+        birthDate: '2002-07-22',
+        remarks: "Dean's list",
+        updated_at: '2025-02-14T10:30:00Z',
+      },
+      {
+        __key: '3',
+        id: 3,
+        firstName: 'Carol',
+        lastName: 'Lee',
+        sex: 'F',
+        age: 21,
+        gpa: 3.5,
+        birthDate: '2003-11-05',
+        remarks: '',
+        updated_at: '2025-03-01T09:15:00Z',
+      },
+    ],
+    total: 3,
+  },
+  subject: {
+    results: [
+      { __key: 'MATH|Mathematics', code: 'MATH', name: 'Mathematics', passingGrade: 50 },
+      { __key: 'PHY|Physics', code: 'PHY', name: 'Physics', passingGrade: 55 },
+      { __key: 'CHEM|Chemistry', code: 'CHEM', name: 'Chemistry', passingGrade: 55 },
+      { __key: 'ENG|English', code: 'ENG', name: 'English', passingGrade: 60 },
+    ],
+    total: 4,
+  },
+  t4t_audit_logs: {
+    results: [
+      {
+        __key: '1',
+        id: 1,
+        user: 'admin',
+        timestamp: '2025-05-01T10:00:00Z',
+        db_name: 'main',
+        table_name: 'student',
+        op: 'INSERT',
+        cols_changed: 'firstName,lastName',
+        new_values: '{"firstName":"Alice","lastName":"Smith"}',
+      },
+      {
+        __key: '2',
+        id: 2,
+        user: 'editor',
+        timestamp: '2025-05-02T14:30:00Z',
+        db_name: 'main',
+        table_name: 'student',
+        op: 'UPDATE',
+        cols_changed: 'gpa',
+        new_values: '{"gpa":3.8}',
+      },
+    ],
+    total: 2,
+  },
+};
+
 export default [
   http.get('http://127.0.0.1:8080/api/msw/test', () => {
-    return HttpResponse.json({
-      message: 'it works :)',
-    });
+    return HttpResponse.json({ message: 'it works :)' });
   }),
-  http.post('http://127.0.0.1:8080/api/auth/login', ({ request, params, cookies }) => {
-    console.log('cookies ? :', cookies);
+
+  // T4t config endpoints
+  http.get('http://127.0.0.1:8080/api/t4t/config/:table', ({ params }) => {
+    const config = T4T_CONFIGS[params.table];
+    if (!config) return HttpResponse.json({ error: 'Table not found' }, { status: 404 });
+    return HttpResponse.json(config);
+  }),
+
+  // T4t find endpoints
+  http.get('http://127.0.0.1:8080/api/t4t/find/:table', ({ params }) => {
+    const data = T4T_DATA[params.table] ?? { results: [], total: 0 };
+    return HttpResponse.json(data);
+  }),
+
+  // Auth endpoints
+  http.post('http://127.0.0.1:8080/api/auth/login', () => {
     return HttpResponse.json({ otp: 1 });
   }),
-  http.post('http://127.0.0.1:8080/api/auth/otp', ({ request, params, cookies }) => {
-    console.log(request.body); // {"id":1,"pin":"111111"}
+  http.post('http://127.0.0.1:8080/api/auth/otp', () => {
     return HttpResponse.json({
       access_token: 'mock-access-token',
       refresh_token: 'mock-refresh-token',
-      user_meta: {
-        email: 'test',
-        roles: ['TestGroup'],
-      },
+      user_meta: { email: 'test', roles: ['TestGroup'] },
     });
   }),
   http.get('http://127.0.0.1:8080/api/auth/logout', () => {
-    return HttpResponse.json({
-      message: 'Logged Out',
-    });
+    return HttpResponse.json({ message: 'Logged Out' });
   }),
 ];

--- a/apps/sample-vue-full/package.json
+++ b/apps/sample-vue-full/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --mode development",
-    "dev:mocked": "vite --config apps/vite.config.js --mode mocked",
+    "dev:mocked": "vite --mode mocked",
     "build": "vite build --mode production",
     "lint": "biome check .",
     "test:e2e": "echo \"Run frontend and backend before playwright test\" && exit 0"

--- a/apps/sample-vue-full/setups/routes.js
+++ b/apps/sample-vue-full/setups/routes.js
@@ -26,19 +26,19 @@ export const SECURE_ROUTES = [
     hidden: true,
   },
   {
-    path: '/t4t-student',
+    path: '/t4t/student',
     name: 'T4t - Student',
     component: async () => import('../views/T4t.vue'),
     props: { tableName: 'student' },
   },
   {
-    path: '/t4t-subject',
+    path: '/t4t/subject',
     name: 'T4t - Subject',
     component: async () => import('../views/T4t.vue'),
     props: { tableName: 'subject' },
   },
   {
-    path: '/audit-logs',
+    path: '/t4t/audit-logs',
     name: 'T4t - Audit Logs',
     component: async () => import('../views/T4t.vue'),
     props: { tableName: 't4t_audit_logs' },

--- a/apps/sample-vue-full/views/DataEntry/DemoCard.vue
+++ b/apps/sample-vue-full/views/DataEntry/DemoCard.vue
@@ -371,13 +371,12 @@ const resetForm = () => {
 }
 
 .section-title {
-  color: #0f172a !important;
+  color: #64748b !important;
   margin: 4px 0 0 !important;
   font-size: 13px !important;
   font-weight: 600 !important;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #64748b !important;
 }
 
 /* Base card */

--- a/apps/sample-vue-full/views/DataEntry/DemoCard.vue
+++ b/apps/sample-vue-full/views/DataEntry/DemoCard.vue
@@ -1,52 +1,513 @@
 <template>
-  <div class="evens">
-    <a-card title="Field Name" class="ds-card">
-      <a-form layout="vertical" :model="formState">
-        <a-form-item label="Field A">
-          <a-input v-model:value="formState.fieldA" placeholder="input placeholder" />
-        </a-form-item>
-        <a-form-item> <a-button type="primary">Submit</a-button> </a-form-item>
-      </a-form>
-    </a-card>
+  <div class="demo-card">
+    <a-row :gutter="[16, 16]">
 
-    <a-card v-for="i in 9" :key="i" hoverable class="ds-card">
-      <template #cover>
-        <img alt="example" src="https://gw.alipayobjects.com/zos/rmsportal/JiqGstEfoWAOHiTxclqi.png">
-      </template>
-      <template #actions>
-        <setting-outlined key="setting" />
-        <edit-outlined key="edit" />
-        <ellipsis-outlined key="ellipsis" />
-      </template>
-      <a-card-meta title="Card title" description="This is the description">
-        <template #avatar>
-          <a-avatar src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png" />
-        </template>
-      </a-card-meta>
-    </a-card>
+      <!-- Section: Basic Cards -->
+      <a-col :span="24">
+        <a-typography-title :level="5" class="section-title">Basic Cards</a-typography-title>
+      </a-col>
+
+      <a-col :xs="24" :sm="8">
+        <a-card :bordered="true" class="base-card">
+          <template #title>
+            <div class="card-title-row"><component :is="icons.FileTextOutlined" class="card-title-icon" /><span>Bordered</span></div>
+          </template>
+          <p class="card-body-text">Default card with visible border. Good for clear visual grouping on white backgrounds.</p>
+          <template #extra><a-tag color="blue">Default</a-tag></template>
+        </a-card>
+      </a-col>
+
+      <a-col :xs="24" :sm="8">
+        <a-card :bordered="false" class="base-card shadow-card">
+          <template #title>
+            <div class="card-title-row"><component :is="icons.AppstoreOutlined" class="card-title-icon" /><span>Shadow</span></div>
+          </template>
+          <p class="card-body-text">Borderless card with box shadow. Works well on light gray page backgrounds.</p>
+          <template #extra><a-tag color="purple">Shadowless border</a-tag></template>
+        </a-card>
+      </a-col>
+
+      <a-col :xs="24" :sm="8">
+        <a-card hoverable class="base-card">
+          <template #title>
+            <div class="card-title-row"><component :is="icons.ThunderboltOutlined" class="card-title-icon" /><span>Hoverable</span></div>
+          </template>
+          <p class="card-body-text">Lift effect on hover. Useful for clickable card grids like product or media listings.</p>
+          <template #extra><a-tag color="green">Hover me</a-tag></template>
+        </a-card>
+      </a-col>
+
+      <!-- Section: Cover Cards -->
+      <a-col :span="24">
+        <a-typography-title :level="5" class="section-title">Cover Cards</a-typography-title>
+      </a-col>
+
+      <a-col v-for="item in coverCards" :key="item.id" :xs="24" :sm="12" :lg="6">
+        <a-card hoverable class="cover-card">
+          <template #cover>
+            <div class="card-cover" :style="{ background: item.gradient }">
+              <component :is="item.icon" class="cover-icon" />
+            </div>
+          </template>
+          <template #actions>
+            <a-tooltip title="Settings"><component :is="icons.SettingOutlined" /></a-tooltip>
+            <a-tooltip title="Edit"><component :is="icons.EditOutlined" /></a-tooltip>
+            <a-tooltip title="More"><component :is="icons.EllipsisOutlined" /></a-tooltip>
+          </template>
+          <a-card-meta :title="item.title" :description="item.desc">
+            <template #avatar>
+              <a-avatar :style="{ background: item.avatarBg }">{{ item.initials }}</a-avatar>
+            </template>
+          </a-card-meta>
+        </a-card>
+      </a-col>
+
+      <!-- Section: Stat Cards -->
+      <a-col :span="24">
+        <a-typography-title :level="5" class="section-title">Statistic Cards</a-typography-title>
+      </a-col>
+
+      <a-col v-for="stat in statCards" :key="stat.title" :xs="12" :sm="6">
+        <a-card :bordered="false" class="stat-card">
+          <a-statistic
+            :title="stat.title"
+            :value="stat.value"
+            :precision="stat.precision"
+            :prefix="stat.prefix"
+            :suffix="stat.suffix"
+            :value-style="{ color: stat.color, fontWeight: 700, fontSize: '20px' }"
+          />
+          <div class="stat-footer">
+            <component :is="stat.trend === 'up' ? icons.ArrowUpOutlined : icons.ArrowDownOutlined"
+              :style="{ color: stat.trend === 'up' ? '#16a34a' : '#dc2626', fontSize: '12px' }"
+            />
+            <span :style="{ color: stat.trend === 'up' ? '#16a34a' : '#dc2626', fontSize: '12px', marginLeft: '4px' }">
+              {{ stat.change }}
+            </span>
+            <span class="stat-sub">vs last month</span>
+          </div>
+        </a-card>
+      </a-col>
+
+      <!-- Section: Tabs Card + Inner Card -->
+      <a-col :xs="24" :lg="14">
+        <a-card :bordered="false" class="base-card shadow-card">
+          <template #title>
+            <div class="card-title-row"><component :is="icons.ProfileOutlined" class="card-title-icon" /><span>Tabbed Card</span></div>
+          </template>
+          <a-tabs v-model:activeKey="activeTab" size="small">
+            <a-tab-pane key="recent" tab="Recent">
+              <a-list size="small" :data-source="recentItems">
+                <template #renderItem="{ item }">
+                  <a-list-item>
+                    <a-list-item-meta :description="item.time">
+                      <template #title>{{ item.title }}</template>
+                      <template #avatar>
+                        <a-avatar :style="{ background: item.color }" size="small">{{ item.initials }}</a-avatar>
+                      </template>
+                    </a-list-item-meta>
+                    <template #actions>
+                      <a-tag :color="item.tag.color" style="font-size:11px">{{ item.tag.label }}</a-tag>
+                    </template>
+                  </a-list-item>
+                </template>
+              </a-list>
+            </a-tab-pane>
+            <a-tab-pane key="popular" tab="Popular">
+              <a-list size="small" :data-source="popularItems">
+                <template #renderItem="{ item }">
+                  <a-list-item>
+                    <a-list-item-meta :description="item.views + ' views'">
+                      <template #title>{{ item.title }}</template>
+                      <template #avatar>
+                        <a-avatar :style="{ background: '#4f46e5' }" size="small">
+                          <template #icon><component :is="icons.StarOutlined" /></template>
+                        </a-avatar>
+                      </template>
+                    </a-list-item-meta>
+                    <template #actions>
+                      <a-rate :value="item.rating" disabled allow-half style="font-size:12px" />
+                    </template>
+                  </a-list-item>
+                </template>
+              </a-list>
+            </a-tab-pane>
+          </a-tabs>
+        </a-card>
+      </a-col>
+
+      <a-col :xs="24" :lg="10">
+        <a-card :bordered="false" class="base-card shadow-card" title="Inner Cards">
+          <a-card type="inner" title="Storage" style="margin-bottom:12px">
+            <a-progress :percent="72" stroke-color="#4f46e5" />
+            <div class="inner-card-meta">72 GB used of 100 GB</div>
+          </a-card>
+          <a-card type="inner" title="Bandwidth">
+            <a-progress :percent="38" stroke-color="#0891b2" status="active" />
+            <div class="inner-card-meta">38 GB used of 100 GB</div>
+          </a-card>
+        </a-card>
+      </a-col>
+
+      <!-- Section: Loading + Form -->
+      <a-col :xs="24" :lg="10">
+        <a-card :bordered="false" class="base-card shadow-card">
+          <template #title>
+            <div class="card-title-row"><component :is="icons.LoadingOutlined" class="card-title-icon" /><span>Loading State</span></div>
+          </template>
+          <template #extra>
+            <a-switch v-model:checked="isLoading" checked-children="On" un-checked-children="Off" />
+          </template>
+          <a-skeleton :loading="isLoading" avatar :paragraph="{ rows: 3 }" active>
+            <a-card-meta
+              title="Content Loaded"
+              description="Toggle the switch above to simulate loading state. Skeleton placeholders maintain layout during async data fetch."
+            >
+              <template #avatar>
+                <a-avatar style="background:#4f46e5">
+                  <template #icon><component :is="icons.UserOutlined" /></template>
+                </a-avatar>
+              </template>
+            </a-card-meta>
+          </a-skeleton>
+        </a-card>
+      </a-col>
+
+      <a-col :xs="24" :lg="14">
+        <a-card :bordered="false" class="base-card shadow-card">
+          <template #title>
+            <div class="card-title-row"><component :is="icons.FormOutlined" class="card-title-icon" /><span>Quick Entry Form</span></div>
+          </template>
+          <a-form :model="formState" layout="vertical">
+            <a-row :gutter="12">
+              <a-col :span="12">
+                <a-form-item label="Field A">
+                  <a-input v-model:value="formState.fieldA" placeholder="Enter value" />
+                </a-form-item>
+              </a-col>
+              <a-col :span="12">
+                <a-form-item label="Field B">
+                  <a-select v-model:value="formState.fieldB" placeholder="Select option" allow-clear>
+                    <a-select-option value="opt1">Option 1</a-select-option>
+                    <a-select-option value="opt2">Option 2</a-select-option>
+                    <a-select-option value="opt3">Option 3</a-select-option>
+                  </a-select>
+                </a-form-item>
+              </a-col>
+            </a-row>
+            <a-form-item label="Notes">
+              <a-textarea v-model:value="formState.notes" :rows="2" placeholder="Optional notes" />
+            </a-form-item>
+            <a-form-item style="margin-bottom:0">
+              <a-space>
+                <a-button type="primary" @click="onSubmit">
+                  <template #icon><component :is="icons.CheckOutlined" /></template>
+                  Submit
+                </a-button>
+                <a-button @click="resetForm">Reset</a-button>
+              </a-space>
+            </a-form-item>
+          </a-form>
+          <Transition name="result-fade">
+            <div v-if="submitMsg" class="result-box">
+              <a-tag color="green">Submitted</a-tag>
+              <pre class="result-json">{{ submitMsg }}</pre>
+            </div>
+          </Transition>
+        </a-card>
+      </a-col>
+
+    </a-row>
   </div>
 </template>
 
 <script setup>
-import { reactive } from 'vue';
+import {
+  AppstoreOutlined,
+  ArrowDownOutlined,
+  ArrowUpOutlined,
+  CheckOutlined,
+  EditOutlined,
+  EllipsisOutlined,
+  FileTextOutlined,
+  FormOutlined,
+  LoadingOutlined,
+  ProfileOutlined,
+  SettingOutlined,
+  StarOutlined,
+  ThunderboltOutlined,
+  UserOutlined,
+} from '@ant-design/icons-vue';
+import { markRaw, reactive, ref } from 'vue';
 
-const formState = reactive({
-  fieldA: '',
+const icons = markRaw({
+  AppstoreOutlined,
+  ArrowDownOutlined,
+  ArrowUpOutlined,
+  CheckOutlined,
+  EditOutlined,
+  EllipsisOutlined,
+  FileTextOutlined,
+  FormOutlined,
+  LoadingOutlined,
+  ProfileOutlined,
+  SettingOutlined,
+  StarOutlined,
+  ThunderboltOutlined,
+  UserOutlined,
 });
+
+// --- Cover cards ---
+const coverCards = [
+  {
+    id: 1,
+    title: 'Analytics',
+    desc: 'Real-time data insights',
+    gradient: 'linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%)',
+    icon: markRaw(AppstoreOutlined),
+    avatarBg: '#4f46e5',
+    initials: 'AN',
+  },
+  {
+    id: 2,
+    title: 'Documents',
+    desc: 'Manage your files',
+    gradient: 'linear-gradient(135deg, #0891b2 0%, #0e7490 100%)',
+    icon: markRaw(FileTextOutlined),
+    avatarBg: '#0891b2',
+    initials: 'DO',
+  },
+  {
+    id: 3,
+    title: 'Projects',
+    desc: 'Track progress & tasks',
+    gradient: 'linear-gradient(135deg, #16a34a 0%, #15803d 100%)',
+    icon: markRaw(ProfileOutlined),
+    avatarBg: '#16a34a',
+    initials: 'PR',
+  },
+  {
+    id: 4,
+    title: 'Performance',
+    desc: 'Speed & reliability metrics',
+    gradient: 'linear-gradient(135deg, #d97706 0%, #b45309 100%)',
+    icon: markRaw(ThunderboltOutlined),
+    avatarBg: '#d97706',
+    initials: 'PE',
+  },
+];
+
+// --- Stat cards ---
+const statCards = [
+  { title: 'Revenue', value: 84200, prefix: '$', color: '#4f46e5', trend: 'up', change: '+14.3%' },
+  { title: 'Users', value: 5312, color: '#0891b2', trend: 'up', change: '+7.1%' },
+  { title: 'Conversion', value: 3.8, precision: 1, suffix: '%', color: '#d97706', trend: 'down', change: '-0.6%' },
+  { title: 'Avg. Session', value: '4m 12s', color: '#16a34a', trend: 'up', change: '+0.8%' },
+];
+
+// --- Tabs card ---
+const activeTab = ref('recent');
+
+const recentItems = [
+  {
+    title: 'Updated user permissions',
+    time: '2 min ago',
+    initials: 'AL',
+    color: '#4f46e5',
+    tag: { label: 'Admin', color: 'purple' },
+  },
+  {
+    title: 'New deployment to staging',
+    time: '18 min ago',
+    initials: 'DV',
+    color: '#0891b2',
+    tag: { label: 'DevOps', color: 'blue' },
+  },
+  {
+    title: 'Invoice #1042 paid',
+    time: '1 hr ago',
+    initials: 'FN',
+    color: '#16a34a',
+    tag: { label: 'Finance', color: 'green' },
+  },
+  {
+    title: 'API rate limit warning',
+    time: '3 hr ago',
+    initials: 'SY',
+    color: '#d97706',
+    tag: { label: 'Alert', color: 'orange' },
+  },
+];
+
+const popularItems = [
+  { title: 'Getting Started Guide', views: '12.4k', rating: 4.5 },
+  { title: 'API Reference Docs', views: '9.8k', rating: 4 },
+  { title: 'Vue Integration Tutorial', views: '7.2k', rating: 5 },
+  { title: 'Authentication Setup', views: '5.1k', rating: 4 },
+];
+
+// --- Loading card ---
+const isLoading = ref(true);
+
+// --- Form card ---
+const formState = reactive({ fieldA: '', fieldB: undefined, notes: '' });
+const submitMsg = ref('');
+
+const onSubmit = () => {
+  submitMsg.value = JSON.stringify(formState, null, 2);
+};
+
+const resetForm = () => {
+  formState.fieldA = '';
+  formState.fieldB = undefined;
+  formState.notes = '';
+  submitMsg.value = '';
+};
 </script>
 
-<style>
-.evens {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: space-around;
-  align-items: stretch;
-  align-content: space-around;
+<style scoped>
+.demo-card {
+  font-family: 'DM Sans', sans-serif;
 }
 
-.ds-card {
-  width: 300px;
-  margin: 8px 16px;
+.section-title {
+  color: #0f172a !important;
+  margin: 4px 0 0 !important;
+  font-size: 13px !important;
+  font-weight: 600 !important;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b !important;
+}
+
+/* Base card */
+.base-card {
+  border-radius: 12px;
+  height: 100%;
+}
+
+.shadow-card {
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.07);
+}
+
+:deep(.base-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.base-card .ant-card-body) {
+  padding: 16px 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+.card-body-text {
+  font-size: 13px;
+  color: #64748b;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Cover cards */
+.cover-card {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.card-cover {
+  height: 110px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cover-icon {
+  font-size: 40px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* Stat cards */
+.stat-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  height: 100%;
+}
+
+:deep(.stat-card .ant-card-body) {
+  padding: 16px 20px;
+}
+
+:deep(.stat-card .ant-statistic-title) {
+  font-size: 12px;
+  color: #64748b;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.stat-footer {
+  display: flex;
+  align-items: center;
+  margin-top: 6px;
+}
+
+.stat-sub {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-left: 6px;
+}
+
+/* Inner card */
+.inner-card-meta {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-top: 4px;
+}
+
+/* Result box */
+.result-box {
+  margin-top: 12px;
+  padding: 10px 14px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+}
+
+.result-json {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #1e293b;
+  font-family: 'Courier New', monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* Form labels */
+:deep(.ant-form-item-label > label) {
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+/* Transition */
+.result-fade-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.result-fade-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
 }
 </style>

--- a/apps/sample-vue-full/views/DataEntry/DemoCascade.vue
+++ b/apps/sample-vue-full/views/DataEntry/DemoCascade.vue
@@ -1,39 +1,173 @@
 <template>
-  <a-form :model="formState" layout="vertical">
-    <h1>Store Counter {{ storeCounter }}</h1>
-    <a-form-item label="Region">
-      <a-select
-        mode="multiple"
-        placeholder="Please select"
-        v-model:value="formState.regions"
-        style="width: 300px"
-        @blur="blurRegion"
-        @deselect="blurRegion"
-      >
-        <a-select-option v-for="region in formState.regionList" :key="region">{{ region }}</a-select-option>
-      </a-select>
-    </a-form-item>
-    <a-form-item label="Countries">
-      <a-select mode="multiple" placeholder="Please select" v-model:value="formState.countries" style="width: 300px">
-        <a-select-option v-for="country in formState.countriesList" :key="country">{{ country }}</a-select-option>
-      </a-select>
-    </a-form-item>
+  <div class="demo-cascade">
+    <a-row :gutter="[16, 16]">
 
-    <a-form-item>
-      <a-button type="primary" @click="onSubmit">Create</a-button>
-      <a-button style="margin-left: 10px">Cancel</a-button>
-    </a-form-item>
-  </a-form>
+      <!-- Cascade Form Card -->
+      <a-col :xs="24" :lg="14">
+        <a-card :bordered="false" class="cascade-card">
+          <template #title>
+            <div class="card-title-row">
+              <ApartmentOutlined class="card-title-icon" />
+              <span>Region & Country Cascade</span>
+            </div>
+          </template>
+          <template #extra>
+            <a-tag :color="storeCounter > 0 ? 'purple' : 'default'">
+              Store Counter: {{ storeCounter }}
+            </a-tag>
+          </template>
+
+          <a-form :model="formState" layout="vertical">
+            <a-form-item label="Region" name="regions">
+              <a-select
+                v-model:value="formState.regions"
+                mode="multiple"
+                placeholder="Select one or more regions"
+                allow-clear
+                :max-tag-count="4"
+                @blur="updateCountries"
+                @deselect="updateCountries"
+              >
+                <a-select-option v-for="region in formState.regionList" :key="region">
+                  {{ region }}
+                </a-select-option>
+              </a-select>
+              <div class="field-hint">Selecting a region filters the available countries below.</div>
+            </a-form-item>
+
+            <a-form-item label="Countries" name="countries">
+              <a-select
+                v-model:value="formState.countries"
+                mode="multiple"
+                placeholder="Select region first, then pick countries"
+                allow-clear
+                :disabled="!formState.countriesList.length"
+                :max-tag-count="6"
+              >
+                <a-select-option v-for="country in formState.countriesList" :key="country">
+                  {{ country }}
+                </a-select-option>
+              </a-select>
+            </a-form-item>
+
+            <a-divider style="margin: 4px 0 16px" />
+
+            <a-form-item style="margin-bottom:0">
+              <a-space>
+                <a-button type="primary" :disabled="!formState.countries.length" @click="onSubmit">
+                  <template #icon><CheckOutlined /></template>
+                  Create
+                </a-button>
+                <a-button @click="resetForm">Reset</a-button>
+              </a-space>
+            </a-form-item>
+          </a-form>
+
+          <Transition name="result-fade">
+            <div v-if="submitResult" class="result-box">
+              <a-tag color="green" style="margin-bottom:6px">Submitted</a-tag>
+              <pre class="result-json">{{ submitResult }}</pre>
+            </div>
+          </Transition>
+        </a-card>
+      </a-col>
+
+      <!-- Summary Card -->
+      <a-col :xs="24" :lg="10">
+        <a-row :gutter="[0, 16]">
+
+          <!-- Selection summary -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="cascade-card">
+              <template #title>
+                <div class="card-title-row">
+                  <UnorderedListOutlined class="card-title-icon" />
+                  <span>Selection Summary</span>
+                </div>
+              </template>
+
+              <a-empty
+                v-if="!formState.regions.length"
+                description="No regions selected"
+                :image="Empty.PRESENTED_IMAGE_SIMPLE"
+                style="margin: 8px 0"
+              />
+
+              <template v-else>
+                <div v-for="region in formState.regions" :key="region" class="region-group">
+                  <div class="region-label">
+                    <GlobalOutlined style="margin-right:6px;color:#4f46e5" />
+                    <span>{{ region }}</span>
+                    <a-badge
+                      :count="selectedByRegion(region).length"
+                      :number-style="{ background: '#4f46e5', fontSize: '10px' }"
+                      style="margin-left:6px"
+                    />
+                  </div>
+                  <div class="region-countries">
+                    <template v-if="selectedByRegion(region).length">
+                      <a-tag
+                        v-for="country in selectedByRegion(region)"
+                        :key="country"
+                        color="blue"
+                        style="margin:2px"
+                      >
+                        {{ country }}
+                      </a-tag>
+                    </template>
+                    <span v-else class="no-country">No countries selected</span>
+                  </div>
+                </div>
+              </template>
+            </a-card>
+          </a-col>
+
+          <!-- Stats -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="cascade-card">
+              <a-row :gutter="0">
+                <a-col :span="8" class="mini-stat">
+                  <a-statistic
+                    title="Regions"
+                    :value="formState.regions.length"
+                    :value-style="{ color: '#4f46e5', fontSize: '22px', fontWeight: 700 }"
+                  />
+                </a-col>
+                <a-col :span="8" class="mini-stat">
+                  <a-statistic
+                    title="Available"
+                    :value="formState.countriesList.length"
+                    :value-style="{ color: '#0891b2', fontSize: '22px', fontWeight: 700 }"
+                  />
+                </a-col>
+                <a-col :span="8" class="mini-stat">
+                  <a-statistic
+                    title="Selected"
+                    :value="formState.countries.length"
+                    :value-style="{ color: '#16a34a', fontSize: '22px', fontWeight: 700 }"
+                  />
+                </a-col>
+              </a-row>
+            </a-card>
+          </a-col>
+
+        </a-row>
+      </a-col>
+
+    </a-row>
+  </div>
 </template>
+
 <script setup>
-import { computed, onMounted, reactive, toRaw } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
+import { ApartmentOutlined, CheckOutlined, GlobalOutlined, UnorderedListOutlined } from '@ant-design/icons-vue';
+// biome-ignore lint/correctness/noUnusedImports: Empty.PRESENTED_IMAGE_SIMPLE used in template
+import { Empty } from 'ant-design-vue';
+import { computed, reactive, ref } from 'vue';
 import { useAppStore } from '../../store.js';
 
-// a-select - allowClear (handle event)
-// TODO select / clear all
-
 const appStore = useAppStore();
-onMounted(() => {});
+const submitResult = ref('');
 
 const formState = reactive({
   regions: [],
@@ -50,30 +184,165 @@ const formState = reactive({
   },
 });
 
-const onSubmit = () => {
-  console.log('submit!', toRaw(formState));
-};
-
-const blurRegion = () => {
-  console.log('blurRegion!', toRaw(formState));
+const updateCountries = () => {
   const keys = {};
   const list = [];
-  const newCountries = [];
+  const retained = [];
+
   for (const region of formState.regions) {
     for (const country of formState.countriesMasterList[region]) {
       if (!keys[country]) {
         list.push(country);
         keys[country] = true;
-        const item = formState.countries.find(item => item === country);
-        if (item) {
-          newCountries.push(item);
-        }
+        if (formState.countries.includes(country)) retained.push(country);
       }
     }
   }
-  formState.countries = [...newCountries];
-  formState.countriesList = [...list];
+
+  formState.countries = retained;
+  formState.countriesList = list;
+};
+
+const selectedByRegion = region => {
+  const regionCountries = formState.countriesMasterList[region] ?? [];
+  return formState.countries.filter(c => regionCountries.includes(c));
+};
+
+const onSubmit = () => {
+  submitResult.value = JSON.stringify({ regions: formState.regions, countries: formState.countries }, null, 2);
+};
+
+const resetForm = () => {
+  formState.regions = [];
+  formState.countries = [];
+  formState.countriesList = [];
+  submitResult.value = '';
 };
 
 const storeCounter = computed(() => appStore.counter);
 </script>
+
+<style scoped>
+.demo-cascade {
+  font-family: 'DM Sans', sans-serif;
+}
+
+.cascade-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  height: 100%;
+}
+
+:deep(.cascade-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.cascade-card .ant-card-body) {
+  padding: 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+:deep(.ant-form-item-label > label) {
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.field-hint {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-top: 4px;
+}
+
+/* Region summary */
+.region-group {
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.region-group:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.region-label {
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 6px;
+}
+
+.region-countries {
+  padding-left: 18px;
+}
+
+.no-country {
+  font-size: 12px;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+/* Mini stats */
+.mini-stat {
+  padding: 4px 12px;
+  border-right: 1px solid #f1f5f9;
+}
+
+.mini-stat:last-child {
+  border-right: none;
+}
+
+:deep(.mini-stat .ant-statistic-title) {
+  font-size: 11px;
+  color: #64748b;
+  font-weight: 500;
+  margin-bottom: 2px;
+}
+
+/* Result box */
+.result-box {
+  margin-top: 16px;
+  padding: 12px 14px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+}
+
+.result-json {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #1e293b;
+  font-family: 'Courier New', monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* Transition */
+.result-fade-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.result-fade-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
+}
+</style>

--- a/apps/sample-vue-full/views/DataEntry/DemoCascade2.vue
+++ b/apps/sample-vue-full/views/DataEntry/DemoCascade2.vue
@@ -1,74 +1,302 @@
 <template>
-  <a-form layout="vertical" :model="formState" ref="formRef">
-    <a-form-item label="Continents">
-      <a-checkbox @change="onCheckAllChange">Select all</a-checkbox>
-      <!-- v-model:checked="checkAll" -->
-      <a-select
-        mode="multiple"
-        placeholder="Please select"
-        v-model:value="formState.continents"
-        @blur="blurSelect"
-        @deselect="blurSelect"
-      >
-        <template #clearIcon> <setting-outlined /> </template>
-        <a-select-option v-for="item in lists.continentsList" :key="item">{{ item }}</a-select-option>
-      </a-select>
-    </a-form-item>
+  <div class="demo-cascade2">
+    <a-row :gutter="[16, 16]">
 
-    <a-form-item label="Countries East Hemisphere">
-      <a-select mode="multiple" placeholder="Please select" v-model:value="formState.countriesEast" allow-clear>
-        <a-select-option v-for="item in lists.countriesEastList" :key="item">{{ item }}</a-select-option>
-      </a-select>
-    </a-form-item>
-    <a-form-item label="Countries West Hemisphere">
-      <a-select
-        mode="multiple"
-        placeholder="Please select"
-        v-model:value="formState.countriesWest"
-        allow-clear
-        @blur="blurSelect2"
-        @deselect="blurSelect2"
-      >
-        <a-select-option v-for="item in lists.countriesWestList" :key="item">{{ item }}</a-select-option>
-      </a-select>
-    </a-form-item>
+      <!-- LEFT: Geography Cascade -->
+      <a-col :xs="24" :lg="15">
+        <a-card :bordered="false" class="cascade-card">
+          <template #title>
+            <div class="card-title-row">
+              <GlobalOutlined class="card-title-icon" />
+              <span>Geography Cascade</span>
+            </div>
+          </template>
 
-    <a-form-item label="Country States (West)">
-      <a-select mode="multiple" placeholder="Please select" v-model:value="formState.westCountryStates">
-        <a-select-option v-for="item in lists.westCountryStatesList" :key="item">{{ item }}</a-select-option>
-      </a-select>
-    </a-form-item>
+          <a-form :model="formState" layout="vertical">
 
-    <!-- Lpoked -->
-    <a-form-item label="Force Include">
-      <a-checkbox @change="onCheckAllChangeIncludes">Select all</a-checkbox>
-      <a-select mode="multiple" placeholder="Please select" v-model:value="formState.forceIncludes">
-        <a-select-option v-for="item in forceListFiltered" :key="item" :value="item"> {{ item }} </a-select-option>
-      </a-select>
-    </a-form-item>
-    <a-form-item label="Force Exclude">
-      <a-checkbox @change="onCheckAllChangeExcludes">Select all</a-checkbox>
-      <a-select mode="multiple" placeholder="Please select" v-model:value="formState.forceExcludes">
-        <a-select-option v-for="item in forceListFiltered" :key="item" :value="item"> {{ item }} </a-select-option>
-      </a-select>
-    </a-form-item>
+            <!-- Continents -->
+            <a-form-item name="continents">
+              <template #label>
+                <div class="field-label-row">
+                  <span>Continents</span>
+                  <a-checkbox
+                    :checked="allContinentsSelected"
+                    :indeterminate="someContinentsSelected"
+                    style="margin-left:12px"
+                    @change="onCheckAllChange"
+                  >
+                    Select all
+                  </a-checkbox>
+                </div>
+              </template>
+              <a-select
+                v-model:value="formState.continents"
+                mode="multiple"
+                placeholder="Select continents"
+                allow-clear
+                :max-tag-count="6"
+                @blur="blurSelect"
+                @deselect="blurSelect"
+                @clear="blurSelect"
+              >
+                <a-select-option v-for="item in lists.continentsList" :key="item">{{ item }}</a-select-option>
+              </a-select>
+            </a-form-item>
 
-    <a-form-item>
-      <a-button type="primary" @click="onSubmit">Run</a-button>
-      <!-- <input type="reset" value="reset"> -->
-      <a-button style="margin-left: 8px" type="primary" @click="onClear">Clear</a-button>
-    </a-form-item>
-  </a-form>
+            <a-divider style="margin: 4px 0 16px">
+              <a-tag color="blue" style="font-size:11px">Driven by Continents</a-tag>
+            </a-divider>
+
+            <!-- East / West Countries side by side -->
+            <a-row :gutter="12">
+              <a-col :xs="24" :sm="12">
+                <a-form-item label="Countries — East Hemisphere" name="countriesEast">
+                  <a-select
+                    v-model:value="formState.countriesEast"
+                    mode="multiple"
+                    placeholder="Asia, Europe, Africa, ME"
+                    allow-clear
+                    :disabled="!lists.countriesEastList.length"
+                    :max-tag-count="4"
+                  >
+                    <a-select-option v-for="item in lists.countriesEastList" :key="item">{{ item }}</a-select-option>
+                  </a-select>
+                </a-form-item>
+              </a-col>
+              <a-col :xs="24" :sm="12">
+                <a-form-item label="Countries — West Hemisphere" name="countriesWest">
+                  <a-select
+                    v-model:value="formState.countriesWest"
+                    mode="multiple"
+                    placeholder="NA, SA"
+                    allow-clear
+                    :disabled="!lists.countriesWestList.length"
+                    :max-tag-count="4"
+                    @blur="blurSelect2"
+                    @deselect="blurSelect2"
+                    @clear="blurSelect2"
+                  >
+                    <a-select-option v-for="item in lists.countriesWestList" :key="item">{{ item }}</a-select-option>
+                  </a-select>
+                </a-form-item>
+              </a-col>
+            </a-row>
+
+            <a-divider style="margin: 4px 0 16px">
+              <a-tag color="cyan" style="font-size:11px">Driven by West Countries</a-tag>
+            </a-divider>
+
+            <!-- States -->
+            <a-form-item label="Country States (West)" name="westCountryStates">
+              <a-select
+                v-model:value="formState.westCountryStates"
+                mode="multiple"
+                placeholder="Select west countries first"
+                allow-clear
+                :disabled="!lists.westCountryStatesList.length"
+                :max-tag-count="6"
+              >
+                <a-select-option v-for="item in lists.westCountryStatesList" :key="item">{{ item }}</a-select-option>
+              </a-select>
+            </a-form-item>
+
+            <a-divider style="margin: 4px 0 16px">
+              <a-tag color="orange" style="font-size:11px">Force Filters</a-tag>
+            </a-divider>
+
+            <!-- Force Include / Exclude side by side -->
+            <a-row :gutter="12">
+              <a-col :xs="24" :sm="12">
+                <a-form-item name="forceIncludes">
+                  <template #label>
+                    <div class="field-label-row">
+                      <span>Force Include</span>
+                      <a-checkbox
+                        :checked="allIncludesSelected"
+                        :indeterminate="someIncludesSelected"
+                        style="margin-left:12px"
+                        @change="onCheckAllChangeIncludes"
+                      >
+                        All
+                      </a-checkbox>
+                    </div>
+                  </template>
+                  <a-select
+                    v-model:value="formState.forceIncludes"
+                    mode="multiple"
+                    placeholder="Select to force include"
+                    allow-clear
+                    :max-tag-count="4"
+                  >
+                    <a-select-option
+                      v-for="item in forceIncludeList"
+                      :key="item"
+                      :value="item"
+                    >
+                      {{ item }}
+                    </a-select-option>
+                  </a-select>
+                </a-form-item>
+              </a-col>
+              <a-col :xs="24" :sm="12">
+                <a-form-item name="forceExcludes">
+                  <template #label>
+                    <div class="field-label-row">
+                      <span>Force Exclude</span>
+                      <a-checkbox
+                        :checked="allExcludesSelected"
+                        :indeterminate="someExcludesSelected"
+                        style="margin-left:12px"
+                        @change="onCheckAllChangeExcludes"
+                      >
+                        All
+                      </a-checkbox>
+                    </div>
+                  </template>
+                  <a-select
+                    v-model:value="formState.forceExcludes"
+                    mode="multiple"
+                    placeholder="Select to force exclude"
+                    allow-clear
+                    :max-tag-count="4"
+                  >
+                    <a-select-option
+                      v-for="item in forceExcludeList"
+                      :key="item"
+                      :value="item"
+                    >
+                      {{ item }}
+                    </a-select-option>
+                  </a-select>
+                </a-form-item>
+              </a-col>
+            </a-row>
+
+            <a-divider style="margin: 4px 0 16px" />
+
+            <a-form-item style="margin-bottom:0">
+              <a-space>
+                <a-button type="primary" @click="onSubmit">
+                  <template #icon><PlayCircleOutlined /></template>
+                  Run
+                </a-button>
+                <a-button @click="onClear">Clear All</a-button>
+              </a-space>
+            </a-form-item>
+          </a-form>
+
+          <Transition name="result-fade">
+            <div v-if="submitResult" class="result-box">
+              <a-tag color="green" style="margin-bottom:6px">Result</a-tag>
+              <pre class="result-json">{{ submitResult }}</pre>
+            </div>
+          </Transition>
+        </a-card>
+      </a-col>
+
+      <!-- RIGHT: Summary -->
+      <a-col :xs="24" :lg="9">
+        <a-row :gutter="[0, 16]">
+
+          <!-- Stats -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="cascade-card">
+              <a-row>
+                <a-col :span="8" class="mini-stat">
+                  <a-statistic
+                    title="Continents"
+                    :value="formState.continents.length"
+                    :value-style="{ color: '#4f46e5', fontSize: '22px', fontWeight: 700 }"
+                  />
+                </a-col>
+                <a-col :span="8" class="mini-stat">
+                  <a-statistic
+                    title="Countries"
+                    :value="totalCountries"
+                    :value-style="{ color: '#0891b2', fontSize: '22px', fontWeight: 700 }"
+                  />
+                </a-col>
+                <a-col :span="8" class="mini-stat">
+                  <a-statistic
+                    title="States"
+                    :value="formState.westCountryStates.length"
+                    :value-style="{ color: '#16a34a', fontSize: '22px', fontWeight: 700 }"
+                  />
+                </a-col>
+              </a-row>
+            </a-card>
+          </a-col>
+
+          <!-- Selection tree -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="cascade-card">
+              <template #title>
+                <div class="card-title-row">
+                  <UnorderedListOutlined class="card-title-icon" />
+                  <span>Selection Tree</span>
+                </div>
+              </template>
+
+              <a-empty
+                v-if="!formState.continents.length"
+                description="No continents selected"
+                :image="Empty.PRESENTED_IMAGE_SIMPLE"
+                style="margin: 8px 0"
+              />
+
+              <a-tree
+                v-else
+                :tree-data="selectionTree"
+                default-expand-all
+                :selectable="false"
+                class="selection-tree"
+              />
+            </a-card>
+          </a-col>
+
+          <!-- Force filters summary -->
+          <a-col v-if="formState.forceIncludes.length || formState.forceExcludes.length" :span="24">
+            <a-card :bordered="false" class="cascade-card">
+              <template #title>
+                <div class="card-title-row">
+                  <FilterOutlined class="card-title-icon" />
+                  <span>Force Filters</span>
+                </div>
+              </template>
+
+              <div v-if="formState.forceIncludes.length" class="force-group">
+                <span class="force-label include">Include</span>
+                <a-tag v-for="item in formState.forceIncludes" :key="item" color="green" style="margin:2px">
+                  {{ item }}
+                </a-tag>
+              </div>
+              <div v-if="formState.forceExcludes.length" class="force-group" style="margin-top:10px">
+                <span class="force-label exclude">Exclude</span>
+                <a-tag v-for="item in formState.forceExcludes" :key="item" color="red" style="margin:2px">
+                  {{ item }}
+                </a-tag>
+              </div>
+            </a-card>
+          </a-col>
+
+        </a-row>
+      </a-col>
+
+    </a-row>
+  </div>
 </template>
 
 <script setup>
-import { computed, onMounted, reactive, ref, toRaw } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
+import { FilterOutlined, GlobalOutlined, PlayCircleOutlined, UnorderedListOutlined } from '@ant-design/icons-vue';
+// biome-ignore lint/correctness/noUnusedImports: Empty.PRESENTED_IMAGE_SIMPLE used in template
+import { Empty } from 'ant-design-vue';
+import { computed, reactive, ref, toRaw } from 'vue';
 
-onMounted(async () => {});
-const formRef = ref();
+const submitResult = ref('');
+
 const lists = reactive({
   continentsList: ['Asia', 'Europe', 'NA', 'SA', 'Africa', 'ME'],
-
   countriesEastList: [],
   countriesEastMasterList: {
     Asia: ['Russia', 'Japan', 'Burma', 'Indonesia', 'Afghanistan'],
@@ -76,13 +304,11 @@ const lists = reactive({
     Africa: ['Egypt', 'Nigeria', 'Kenya', 'Liberia'],
     ME: ['Egypt', 'Saudi Arabia', 'Afghanistan'],
   },
-
   countriesWestList: [],
   countriesWestMasterList: {
     NA: ['United States', 'Canada'],
     SA: ['Brazil', 'Argentina', 'Ecuador'],
   },
-
   westCountryStatesList: [],
   westCountryStatesMasterList: {
     'United States': ['California', 'New York', 'Ohio', 'Utah', 'Texas'],
@@ -94,7 +320,6 @@ const lists = reactive({
 });
 
 const formState = reactive({
-  // form
   forceIncludes: [],
   forceExcludes: [],
   continents: [],
@@ -103,143 +328,265 @@ const formState = reactive({
   westCountryStates: [],
 });
 
-const onCheckAllChange = e => {
-  if (e.target.checked === true) {
-    formState.continents = [...lists.continentsList];
-    blurSelect(); // select all countriesEast / countriesWest
-  } else {
-    formState.continents = [];
-    blurSelect(); // clear all countriesEast / countriesWest
+// --- Cascade logic ---
+const cascadeDown = (sourceKey, subs) => {
+  for (const sub of subs) {
+    const { subKey, subKeyMasterList, subKeyList } = sub;
+    const seen = {};
+    const list = [];
+    const retained = [];
+    for (const item of formState[sourceKey]) {
+      for (const subItem of lists[subKeyMasterList][item] ?? []) {
+        if (!seen[subItem]) {
+          list.push(subItem);
+          seen[subItem] = true;
+          if (formState[subKey].includes(subItem)) retained.push(subItem);
+        }
+      }
+    }
+    formState[subKey] = retained;
+    lists[subKeyList] = list;
   }
 };
 
 const blurSelect = () => {
-  // console.log('blurSelect!', toRaw(formState));
-  const key = 'continents';
-  const subs = [
-    {
-      subKey: 'countriesEast',
-      subKeyMasterList: 'countriesEastMasterList',
-      subKeyList: 'countriesEastList',
-    },
-    {
-      subKey: 'countriesWest',
-      subKeyMasterList: 'countriesWestMasterList',
-      subKeyList: 'countriesWestList',
-    },
-    // can add more...
-  ];
-  for (let sub of subs) {
-    // all dropdowns affected
-    const { subKey, subKeyMasterList, subKeyList } = sub;
-    const keys = {};
-    const list = [];
-    const newSelected = [];
-    for (let _item of formState[key]) {
-      // loop continent from continents
-      if (lists[subKeyMasterList][_item]) {
-        for (let _subItem of lists[subKeyMasterList][_item]) {
-          // loop through every country in a continent
-          if (!keys[_subItem]) {
-            list.push(_subItem);
-            keys[_subItem] = true;
-            const found = formState[subKey].find(item => item === _subItem);
-            if (found) newSelected.push(found);
-          }
-        }
-      }
-    }
-    formState[subKey] = [...newSelected];
-    lists[subKeyList] = [...list];
-  }
+  cascadeDown('continents', [
+    { subKey: 'countriesEast', subKeyMasterList: 'countriesEastMasterList', subKeyList: 'countriesEastList' },
+    { subKey: 'countriesWest', subKeyMasterList: 'countriesWestMasterList', subKeyList: 'countriesWestList' },
+  ]);
   blurSelect2();
 };
 
 const blurSelect2 = () => {
-  // console.log('blurSelect!', toRaw(formState));
-  const key = 'countriesWest';
-  const subs = [
+  cascadeDown('countriesWest', [
     {
       subKey: 'westCountryStates',
       subKeyMasterList: 'westCountryStatesMasterList',
       subKeyList: 'westCountryStatesList',
     },
-  ];
-  for (let sub of subs) {
-    // all dropdowns affected
-    const { subKey, subKeyMasterList, subKeyList } = sub;
-    const keys = {};
-    const list = [];
-    const newSelected = [];
-    for (let _item of formState[key]) {
-      // loop country from list of countries
-      if (lists[subKeyMasterList][_item]) {
-        // start
-        for (let _subItem of lists[subKeyMasterList][_item]) {
-          // loop through every state in a country
-          if (!keys[_subItem]) {
-            list.push(_subItem);
-            keys[_subItem] = true;
-            const found = formState[subKey].find(item => item === _subItem);
-            if (found) newSelected.push(found);
-          }
-        }
-        // end
-      }
-    }
-    formState[subKey] = [...newSelected];
-    lists[subKeyList] = [...list];
-  }
+  ]);
 };
 
-const forceListFiltered = computed(() =>
-  forceList.filter(o => !formState.forceIncludes.includes(o) && !formState.forceExcludes.includes(o)),
-);
+// --- Continent select all ---
+const allContinentsSelected = computed(() => formState.continents.length === lists.continentsList.length);
+const someContinentsSelected = computed(() => formState.continents.length > 0 && !allContinentsSelected.value);
+
+const onCheckAllChange = e => {
+  formState.continents = e.target.checked ? [...lists.continentsList] : [];
+  blurSelect();
+};
+
+// --- Force lists ---
 const forceList = ['aa1', 'aa22', 'aa23', 'aa4', 'aa5', 'bb1', 'bb22', 'bb23', 'bb4', 'bb5'];
 
+const forceIncludeList = computed(() => forceList.filter(o => !formState.forceExcludes.includes(o)));
+const forceExcludeList = computed(() => forceList.filter(o => !formState.forceIncludes.includes(o)));
+
+const allIncludesSelected = computed(
+  () => formState.forceIncludes.length === forceIncludeList.value.length && forceIncludeList.value.length > 0,
+);
+const someIncludesSelected = computed(() => formState.forceIncludes.length > 0 && !allIncludesSelected.value);
+const allExcludesSelected = computed(
+  () => formState.forceExcludes.length === forceExcludeList.value.length && forceExcludeList.value.length > 0,
+);
+const someExcludesSelected = computed(() => formState.forceExcludes.length > 0 && !allExcludesSelected.value);
+
 const onCheckAllChangeIncludes = e => {
-  if (e.target.checked) {
-    formState.forceIncludes = [
-      ...formState.forceIncludes,
-      ...forceList.filter(o => !formState.forceIncludes.includes(o) && !formState.forceExcludes.includes(o)),
-    ];
-  } else {
-    formState.forceIncludes = [];
-  }
+  formState.forceIncludes = e.target.checked ? [...forceIncludeList.value] : [];
 };
 
 const onCheckAllChangeExcludes = e => {
-  if (e.target.checked) {
-  } else {
-    formState.forceExlcudes = [];
-  }
+  formState.forceExcludes = e.target.checked ? [...forceExcludeList.value] : [];
 };
 
-const onSubmit = async () => {
-  console.log('submit!', toRaw(formState));
-};
+// --- Stats ---
+const totalCountries = computed(() => formState.countriesEast.length + formState.countriesWest.length);
 
-const labelCol = {
-  // form
-  span: 4,
-};
+// --- Selection tree for a-tree ---
+const selectionTree = computed(() => {
+  return formState.continents.map(continent => {
+    const eastCountries = (lists.countriesEastMasterList[continent] ?? []).filter(c =>
+      formState.countriesEast.includes(c),
+    );
+    const westCountries = (lists.countriesWestMasterList[continent] ?? []).filter(c =>
+      formState.countriesWest.includes(c),
+    );
+    const allCountries = [...eastCountries, ...westCountries];
 
-const wrapperCol = {
-  span: 14,
-};
+    return {
+      title: continent,
+      key: continent,
+      children: allCountries.map(country => {
+        const states = (lists.westCountryStatesMasterList[country] ?? []).filter(s =>
+          formState.westCountryStates.includes(s),
+        );
+        return {
+          title: country,
+          key: `${continent}-${country}`,
+          children: states.map(s => ({ title: s, key: `${continent}-${country}-${s}` })),
+        };
+      }),
+    };
+  });
+});
 
-// :tip-formatter="formatter"
-// const formatter = value => {
-//   return `${value}%`;
-// }
+// --- Submit / Clear ---
+const onSubmit = () => {
+  const raw = toRaw(formState);
+  submitResult.value = JSON.stringify(
+    {
+      continents: raw.continents,
+      countriesEast: raw.countriesEast,
+      countriesWest: raw.countriesWest,
+      westCountryStates: raw.westCountryStates,
+      forceIncludes: raw.forceIncludes,
+      forceExcludes: raw.forceExcludes,
+    },
+    null,
+    2,
+  );
+};
 
 const onClear = () => {
-  // formRef.value.resetFields() //  does not work
   formState.forceIncludes = [];
   formState.forceExcludes = [];
   formState.continents = [];
   formState.countriesEast = [];
   formState.countriesWest = [];
   formState.westCountryStates = [];
+  lists.countriesEastList = [];
+  lists.countriesWestList = [];
+  lists.westCountryStatesList = [];
+  submitResult.value = '';
 };
 </script>
+
+<style scoped>
+.demo-cascade2 {
+  font-family: 'DM Sans', sans-serif;
+}
+
+.cascade-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  height: 100%;
+}
+
+:deep(.cascade-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.cascade-card .ant-card-body) {
+  padding: 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+:deep(.ant-form-item-label > label) {
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.field-label-row {
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+/* Mini stats */
+.mini-stat {
+  padding: 4px 12px;
+  border-right: 1px solid #f1f5f9;
+}
+
+.mini-stat:last-child {
+  border-right: none;
+}
+
+:deep(.mini-stat .ant-statistic-title) {
+  font-size: 11px;
+  color: #64748b;
+  font-weight: 500;
+  margin-bottom: 2px;
+}
+
+/* Selection tree */
+.selection-tree {
+  font-size: 13px;
+}
+
+:deep(.selection-tree .ant-tree-node-content-wrapper) {
+  color: #1e293b;
+}
+
+/* Force filters */
+.force-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px;
+}
+
+.force-label {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 1px 8px;
+  border-radius: 10px;
+  margin-right: 4px;
+}
+
+.force-label.include {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.force-label.exclude {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+/* Result box */
+.result-box {
+  margin-top: 16px;
+  padding: 12px 14px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+}
+
+.result-json {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #1e293b;
+  font-family: 'Courier New', monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* Transition */
+.result-fade-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.result-fade-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
+}
+</style>

--- a/apps/sample-vue-full/views/DataEntry/DemoCascade2.vue
+++ b/apps/sample-vue-full/views/DataEntry/DemoCascade2.vue
@@ -554,12 +554,12 @@ const onClear = () => {
 
 .force-label.include {
   background: #dcfce7;
-  color: #16a34a;
+  color: #166534;
 }
 
 .force-label.exclude {
   background: #fee2e2;
-  color: #dc2626;
+  color: #991b1b;
 }
 
 /* Result box */

--- a/apps/sample-vue-full/views/DataEntry/DemoForm.vue
+++ b/apps/sample-vue-full/views/DataEntry/DemoForm.vue
@@ -323,7 +323,7 @@ const handleRemove = file => {
 };
 
 const beforeUpload = file => {
-  if (!form1.files.find(f => f.name === file.name)) {
+  if (!form1.files.some(f => f.name === file.name)) {
     form1.files = [...form1.files, file];
   }
   return false;

--- a/apps/sample-vue-full/views/DataEntry/DemoForm.vue
+++ b/apps/sample-vue-full/views/DataEntry/DemoForm.vue
@@ -1,259 +1,511 @@
 <template>
-  <a-collapse v-model:activeKey="activeKey">
-    <a-collapse-panel key="1" header="Form - Test Upload Files and JSON data">
-      <a-form :model="formState" :label-col="labelCol" :wrapper-col="wrapperCol">
-        <a-upload-dragger
-          :file-list="form1.files"
-          :remove="handleRemove"
-          :before-upload="beforeUpload"
-          :multiple="true"
-        >
-          <p class="ant-upload-drag-icon"><inbox-outlined></inbox-outlined></p>
-          <p class="ant-upload-text">Click or drag file to this area to upload</p>
-          <p class="ant-upload-hint">
-            Support for a single or bulk upload. Strictly prohibit from uploading company data or other band files
-          </p>
-        </a-upload-dragger>
-        <a-form-item label="Text Input"> <a-input v-model:value="form1.text" /> </a-form-item>
-        <a-form-item label="Number Input"> <a-input v-model:value="form1.number" type="number" /> </a-form-item>
-        <a-form-item :wrapper-col="{ span: 14, offset: 4 }">
-          <a-button type="primary" @click="onSubmit1">Upload</a-button>
-        </a-form-item>
-      </a-form>
-    </a-collapse-panel>
-    <a-collapse-panel key="2" :header="`Form - Test Various Inputs (Store Counter: ${storeCounter})`">
-      <a-form :model="formState" :label-col="labelCol" :wrapper-col="wrapperCol">
-        <a-form-item label="Test Slider">
-          <a-input-group compact>
-            <a-slider style="width: 80%" :min="1" :max="20" v-model:value="formState.rating" />
-            <a-input style="width: 16%; float: right" v-model:value="formState.rating" />
-          </a-input-group>
-        </a-form-item>
-        <a-form-item label="Activity name"> <a-input v-model:value="formState.name" /> </a-form-item>
-        <a-form-item label="Activity zone">
-          <a-select v-model:value="formState.region" placeholder="please select your zone">
-            <a-select-option value="shanghai">Zone one</a-select-option>
-            <a-select-option value="beijing">Zone two</a-select-option>
-          </a-select>
-        </a-form-item>
-        <a-form-item label="Activity time">
-          <!-- <a-date-picker
-            v-model:value="formState.date1" show-time type="date" placeholder="Pick a date" style="width: 100%"
-          /> -->
-          <a-input v-model:value="appStore.form.date1" type="date" placeholder="Pick a date" style="width: 100%" />
-        </a-form-item>
-        <a-form-item label="Instant delivery"> <a-switch v-model:checked="appStore.form.delivery" /> </a-form-item>
-        <a-form-item label="Activity type">
-          <a-checkbox-group v-model:value="formState.type">
-            <a-checkbox value="1" name="type">Online</a-checkbox>
-            <a-checkbox value="2" name="type">Promotion</a-checkbox>
-            <a-checkbox value="3" name="type">Offline</a-checkbox>
-          </a-checkbox-group>
-        </a-form-item>
-        <a-form-item label="Resources">
-          <a-radio-group v-model:value="formState.resource">
-            <a-radio value="1">Sponsor</a-radio>
-            <a-radio value="2">Venue</a-radio>
-          </a-radio-group>
-        </a-form-item>
-        <a-form-item label="Activity form"> <a-input v-model:value="formState.desc" type="textarea" /> </a-form-item>
-        <a-form-item label="Modify Store Counter"> <a-input v-model:value="storeCounter" type="number" /> </a-form-item>
-        <a-form-item :wrapper-col="{ span: 14, offset: 4 }">
-          <a-button type="primary" @click="onSubmit">Create</a-button>
-          <a-button style="margin-left: 10px">Cancel</a-button>
-        </a-form-item>
-        Create Response: {{ submitResult || 'No Response' }}
-      </a-form>
-    </a-collapse-panel>
-    <a-collapse-panel key="3" header="Transfer" collapsible="header">
-      <a-transfer
-        :data-source="mockData"
-        show-search
-        :list-style="{
-          width: '250px',
-          height: '300px'
-        }"
-        :operations="['to right', 'to left']"
-        :target-keys="targetKeys"
-        :render="(item) => `${item.title}-${item.description}`"
-        @change="handleChange"
-      >
-        <template #footer>
-          <a-button size="small" style="float: right; margin: 5px" @click="getMock">reload</a-button>
-        </template>
-        <template #notFoundContent> <span>没数据</span> </template>
-      </a-transfer>
-    </a-collapse-panel>
-    <a-collapse-panel key="4" :header="`Form - Test Web Socket`">
-      <a-form :model="formState" :label-col="labelCol" :wrapper-col="wrapperCol">
-        <a-form-item label="Message To Send"> <a-input v-model:value="wsMsg" /> </a-form-item>
-        <a-form-item :wrapper-col="{ span: 14, offset: 4 }">
-          <a-button type="primary" @click="onWsMsg">Send WS Message</a-button>
-        </a-form-item>
-        WS Rx Message: {{ appStore.message || 'No WS Message' }}
-      </a-form>
-    </a-collapse-panel>
-    <a-collapse-panel key="5" :header="`Form - Test Forbidden & Not Found`">
-      <a-button @click="goToForbidden">Forbidden</a-button>
-      <a-button @click="goToNotFound">Not Found</a-button>
-    </a-collapse-panel>
-  </a-collapse>
+  <div class="demo-form">
+    <a-row :gutter="[16, 16]">
+
+      <!-- LEFT COLUMN -->
+      <a-col :xs="24" :lg="15">
+
+        <!-- Various Inputs -->
+        <a-card :bordered="false" class="form-card">
+          <template #title>
+            <div class="card-title-row">
+              <FormOutlined class="card-title-icon" />
+              <span>Various Inputs</span>
+              <a-badge
+                :count="storeCounter"
+                :number-style="{ background: '#4f46e5' }"
+                style="margin-left:auto"
+              />
+            </div>
+          </template>
+
+          <a-form :model="formState" :label-col="{ span: 6 }" :wrapper-col="{ span: 18 }" layout="horizontal">
+            <a-form-item label="Rating">
+              <a-row :gutter="12">
+                <a-col :span="17">
+                  <a-slider v-model:value="formState.rating" :min="1" :max="20" />
+                </a-col>
+                <a-col :span="7">
+                  <a-input-number v-model:value="formState.rating" :min="1" :max="20" style="width:100%" />
+                </a-col>
+              </a-row>
+            </a-form-item>
+
+            <a-form-item label="Activity name">
+              <a-input v-model:value="formState.name" placeholder="Enter activity name" />
+            </a-form-item>
+
+            <a-form-item label="Zone">
+              <a-select v-model:value="formState.region" placeholder="Select a zone" allow-clear>
+                <a-select-option value="shanghai">Zone One</a-select-option>
+                <a-select-option value="beijing">Zone Two</a-select-option>
+              </a-select>
+            </a-form-item>
+
+            <a-form-item label="Date">
+              <a-date-picker
+                v-model:value="appStore.form.date1"
+                show-time
+                placeholder="Pick a date"
+                style="width:100%"
+                value-format="YYYY-MM-DD HH:mm:ss"
+              />
+            </a-form-item>
+
+            <a-form-item label="Instant delivery">
+              <a-switch
+                v-model:checked="appStore.form.delivery"
+                checked-children="On"
+                un-checked-children="Off"
+              />
+            </a-form-item>
+
+            <a-form-item label="Type">
+              <a-checkbox-group v-model:value="formState.type">
+                <a-checkbox value="1">Online</a-checkbox>
+                <a-checkbox value="2">Promotion</a-checkbox>
+                <a-checkbox value="3">Offline</a-checkbox>
+              </a-checkbox-group>
+            </a-form-item>
+
+            <a-form-item label="Resources">
+              <a-radio-group v-model:value="formState.resource">
+                <a-radio value="1">Sponsor</a-radio>
+                <a-radio value="2">Venue</a-radio>
+              </a-radio-group>
+            </a-form-item>
+
+            <a-form-item label="Description">
+              <a-textarea
+                v-model:value="formState.desc"
+                :rows="3"
+                placeholder="Enter activity description"
+                show-count
+                :maxlength="300"
+              />
+            </a-form-item>
+
+            <a-form-item label="Store counter">
+              <a-input-number v-model:value="storeCounter" :min="0" style="width:100%" />
+            </a-form-item>
+
+            <a-divider style="margin: 12px 0" />
+
+            <a-form-item :wrapper-col="{ span: 18, offset: 6 }">
+              <a-space>
+                <a-button type="primary" :loading="submitting" @click="onSubmit">
+                  <template #icon><CheckOutlined /></template>
+                  Create
+                </a-button>
+                <a-button @click="resetForm">Reset</a-button>
+              </a-space>
+            </a-form-item>
+          </a-form>
+
+          <Transition name="result-fade">
+            <div v-if="submitResult" class="result-box">
+              <a-tag :color="submitResult.ok ? 'green' : 'red'" style="margin-bottom:6px">
+                {{ submitResult.ok ? 'Success' : 'Error' }}
+              </a-tag>
+              <pre class="result-json">{{ submitResult.msg }}</pre>
+            </div>
+          </Transition>
+        </a-card>
+
+        <!-- Transfer -->
+        <a-card :bordered="false" class="form-card" style="margin-top:16px">
+          <template #title>
+            <div class="card-title-row">
+              <SwapOutlined class="card-title-icon" />
+              <span>Transfer List</span>
+            </div>
+          </template>
+          <template #extra>
+            <a-button size="small" @click="getMock">
+              <template #icon><ReloadOutlined /></template>
+              Reload
+            </a-button>
+          </template>
+
+          <div class="transfer-wrap">
+            <a-transfer
+              :data-source="mockData"
+              show-search
+              :list-style="{ flex: 1, height: '280px' }"
+              :operations="['Add →', '← Remove']"
+              :target-keys="targetKeys"
+              :render="item => `${item.title} — ${item.description}`"
+              @change="handleChange"
+            >
+              <template #notFoundContent>
+                <a-empty description="No data" :image="Empty.PRESENTED_IMAGE_SIMPLE" />
+              </template>
+            </a-transfer>
+          </div>
+        </a-card>
+
+      </a-col>
+
+      <!-- RIGHT COLUMN -->
+      <a-col :xs="24" :lg="9">
+
+        <!-- File Upload -->
+        <a-card :bordered="false" class="form-card">
+          <template #title>
+            <div class="card-title-row">
+              <UploadOutlined class="card-title-icon" />
+              <span>File Upload</span>
+            </div>
+          </template>
+
+          <a-form :model="form1" layout="vertical">
+            <a-form-item label="Files">
+              <a-upload-dragger
+                :file-list="form1.files"
+                :remove="handleRemove"
+                :before-upload="beforeUpload"
+                :multiple="true"
+                class="upload-dragger"
+              >
+                <p class="ant-upload-drag-icon"><InboxOutlined /></p>
+                <p class="ant-upload-text">Click or drag files here</p>
+                <p class="ant-upload-hint">Single or bulk upload supported.</p>
+              </a-upload-dragger>
+            </a-form-item>
+
+            <a-form-item label="Text">
+              <a-input v-model:value="form1.text" placeholder="Enter text" />
+            </a-form-item>
+
+            <a-form-item label="Number">
+              <a-input-number v-model:value="form1.number" :min="0" style="width:100%" />
+            </a-form-item>
+
+            <a-button type="primary" block :loading="uploading" @click="onSubmit1">
+              <template #icon><UploadOutlined /></template>
+              Upload
+            </a-button>
+          </a-form>
+
+          <Transition name="result-fade">
+            <div v-if="uploadResult" class="result-box" style="margin-top:12px">
+              <a-tag :color="uploadResult.ok ? 'green' : 'red'" style="margin-bottom:6px">
+                {{ uploadResult.ok ? 'Success' : 'Error' }}
+              </a-tag>
+              <pre class="result-json">{{ uploadResult.msg }}</pre>
+            </div>
+          </Transition>
+        </a-card>
+
+        <!-- WebSocket -->
+        <a-card :bordered="false" class="form-card" style="margin-top:16px">
+          <template #title>
+            <div class="card-title-row">
+              <WifiOutlined class="card-title-icon" />
+              <span>WebSocket Test</span>
+            </div>
+          </template>
+
+          <a-form layout="vertical">
+            <a-form-item label="Message">
+              <a-input
+                v-model:value="wsMsg"
+                placeholder="Type a message"
+                allow-clear
+                @press-enter="onWsMsg"
+              />
+            </a-form-item>
+
+            <a-button type="primary" block @click="onWsMsg">
+              <template #icon><SendOutlined /></template>
+              Send
+            </a-button>
+
+            <a-divider style="margin: 14px 0" />
+
+            <div class="ws-received">
+              <span class="ws-label">Received</span>
+              <a-tag :color="appStore.message ? 'blue' : 'default'" style="margin-left:8px">
+                {{ appStore.message || 'No message yet' }}
+              </a-tag>
+            </div>
+          </a-form>
+        </a-card>
+
+        <!-- Error Pages -->
+        <a-card :bordered="false" class="form-card" style="margin-top:16px">
+          <template #title>
+            <div class="card-title-row">
+              <WarningOutlined class="card-title-icon" />
+              <span>Error Pages</span>
+            </div>
+          </template>
+
+          <a-space direction="vertical" style="width:100%">
+            <a-button block danger @click="goToForbidden">
+              <template #icon><StopOutlined /></template>
+              403 Forbidden
+            </a-button>
+            <a-button block @click="goToNotFound">
+              <template #icon><QuestionCircleOutlined /></template>
+              404 Not Found
+            </a-button>
+          </a-space>
+        </a-card>
+
+      </a-col>
+    </a-row>
+  </div>
 </template>
 
 <script setup>
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
+import {
+  CheckOutlined,
+  FormOutlined,
+  InboxOutlined,
+  QuestionCircleOutlined,
+  ReloadOutlined,
+  SendOutlined,
+  StopOutlined,
+  SwapOutlined,
+  UploadOutlined,
+  WarningOutlined,
+  WifiOutlined,
+} from '@ant-design/icons-vue';
 import { http } from '@common/vue/plugins/fetch.js';
 import { ws } from '@common/vue/plugins/ws.js';
-import { computed, onBeforeUnmount, onMounted, reactive, ref, toRaw, watch } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: Empty.PRESENTED_IMAGE_SIMPLE used in template
+import { Empty } from 'ant-design-vue';
+import { computed, onMounted, reactive, ref, toRaw } from 'vue';
 import { useRouter } from 'vue-router';
-// v-model:fileList="form1.files"
 import { useAppStore } from '../../store.js';
 
 const { VITE_API_URL } = import.meta.env;
 
 const appStore = useAppStore();
 const router = useRouter();
-const submitResult = ref('');
-const mockData = ref([]); // transfer
+
+// --- Transfer ---
+const mockData = ref([]);
 const targetKeys = ref([]);
 
 const getMock = () => {
   const keys = [];
   const mData = [];
-
   for (let i = 0; i < 20; i++) {
     const data = {
       key: i.toString(),
-      title: `content${i + 1}`,
-      description: `description of content${i + 1}`,
+      title: `Item ${i + 1}`,
+      description: `Description ${i + 1}`,
       chosen: Math.random() * 2 > 1,
     };
-
-    if (data.chosen) {
-      keys.push(data.key);
-    }
-
+    if (data.chosen) keys.push(data.key);
     mData.push(data);
   }
-
   mockData.value = mData;
   targetKeys.value = keys;
 };
 
-const handleChange = (keys, direction, moveKeys) => {
+const handleChange = keys => {
   targetKeys.value = keys;
-  // console.log(keys, direction, moveKeys)
 };
 
-onMounted(() => {
-  getMock();
-  // ws.setMessage((e) => {
-  //   console.log('ws onmessage', e.data)
-  //   appStore.message = e.data
-  // })
-});
+onMounted(getMock);
 
-onBeforeUnmount(() => {
-  // ws.setMessage((e) => console.log('ws onmessage', e.data))
-});
+// --- Form 1: File Upload ---
+const form1 = reactive({ files: [], text: 'abcd', number: 3 });
+const uploading = ref(false);
+const uploadResult = ref(null);
 
-// accordian
-const activeKey = ref(['1']);
-watch(activeKey, val => console.log(val));
+const handleRemove = file => {
+  form1.files = form1.files.filter(f => f.uid !== file.uid);
+};
 
-// form
+const beforeUpload = file => {
+  if (!form1.files.find(f => f.name === file.name)) {
+    form1.files = [...form1.files, file];
+  }
+  return false;
+};
+
+const onSubmit1 = async () => {
+  uploading.value = true;
+  uploadResult.value = null;
+  try {
+    const form = new FormData();
+    for (const file of form1.files) form.append('myfiles', file);
+    form.append('mydata', JSON.stringify({ text: form1.text, number: form1.number }));
+    const { data } = await http.post(`${VITE_API_URL}/api/custom-app/uploads/file-and-json`, form);
+    uploadResult.value = { ok: true, msg: JSON.stringify(data, null, 2) };
+  } catch (e) {
+    uploadResult.value = { ok: false, msg: e?.data ? JSON.stringify(e.data, null, 2) : e.toString() };
+  }
+  uploading.value = false;
+};
+
+// --- Form 2: Various Inputs ---
 const formState = reactive({
   name: '',
   region: undefined,
-  // date1: undefined,
-  // delivery: false,
   type: [],
   resource: '',
   desc: '',
   rating: 5,
 });
 
+const submitting = ref(false);
+const submitResult = ref(null);
+
 const onSubmit = async () => {
-  console.log('submit!');
+  submitting.value = true;
+  submitResult.value = null;
   try {
     const body = toRaw(formState);
-    console.log('submit!', body);
     const { data } = await http.post(`${VITE_API_URL}/api/healthcheck`, body);
-    console.log(data);
-    submitResult.value = JSON.stringify(data);
+    submitResult.value = { ok: true, msg: JSON.stringify(data, null, 2) };
   } catch (e) {
-    console.log('onSubmit Error', e.toString());
-    submitResult.value = e.toString();
+    submitResult.value = { ok: false, msg: e?.data ? JSON.stringify(e.data, null, 2) : e.toString() };
   }
+  submitting.value = false;
 };
 
-const form1 = reactive({
-  files: [],
-  text: 'abcd',
-  number: 3,
-});
-
-const onSubmit1 = async () => {
-  try {
-    console.log('submit', form1.files);
-
-    // submit the data here
-    const form = new FormData();
-    for (let file of form1.files) {
-      form.append('myfiles', file);
-    }
-    form.append(
-      'mydata',
-      JSON.stringify({
-        text: form1.text,
-        number: form1.number,
-      }),
-    );
-    const { data } = await http.post(`${VITE_API_URL}/api/custom-app/uploads/file-and-json`, form);
-    console.log(data);
-  } catch (e) {
-    console.log('onSubmit1 Error', e.toString());
-  }
+const resetForm = () => {
+  formState.name = '';
+  formState.region = undefined;
+  formState.type = [];
+  formState.resource = '';
+  formState.desc = '';
+  formState.rating = 5;
+  submitResult.value = null;
 };
 
-const handleRemove = file => {
-  const newFileList = form1.files.filter(f => f.uid !== file.uid); // do not handle if same filename
-  form1.files = newFileList;
-};
-
-const beforeUpload = file => {
-  console.log('beforeUpload', file);
-  const found = form1.files.find(f => f.name === file.name);
-  console.log(form1.files);
-  if (!found) {
-    console.log('adding');
-    form1.files = [...form1.files, file];
-  } else {
-    // remove from list?...
-  }
-  return false;
-};
-
-watch(
-  () => appStore.form,
-  (currentValue, oldValue) => {
-    console.log('watch', currentValue, oldValue);
-  },
-  { deep: true },
-);
-
-const wsMsg = ref(''); // websockets
-const onWsMsg = e => {
+// --- WebSocket ---
+const wsMsg = ref('');
+const onWsMsg = () => {
   ws.send(wsMsg.value);
 };
 
+// --- Navigation ---
 const goToNotFound = () => router.push('/notfound');
 const goToForbidden = () => router.push('/forbidden');
 
-const labelCol = { span: 4 };
-const wrapperCol = { span: 14 };
-
+// --- Store counter ---
 const storeCounter = computed({
   get: () => appStore.counter,
-  set: val => (appStore.counter = val),
+  set: val => {
+    appStore.counter = val;
+  },
 });
 </script>
+
+<style scoped>
+.demo-form {
+  font-family: 'DM Sans', sans-serif;
+}
+
+.form-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+:deep(.form-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.form-card .ant-card-body) {
+  padding: 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  width: 100%;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+/* Form labels */
+:deep(.ant-form-item-label > label) {
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+/* Upload dragger */
+.upload-dragger {
+  border-radius: 10px;
+}
+
+/* Transfer */
+.transfer-wrap {
+  overflow-x: auto;
+}
+
+:deep(.ant-transfer) {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+}
+
+:deep(.ant-transfer-list) {
+  flex: 1;
+  border-radius: 8px;
+  border-color: #e2e8f0;
+  min-width: 0;
+}
+
+:deep(.ant-transfer-list-header) {
+  background: #f8fafc;
+  border-color: #e2e8f0;
+}
+
+/* WS received row */
+.ws-received {
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  color: #64748b;
+}
+
+.ws-label {
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* Result box */
+.result-box {
+  padding: 12px 14px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+}
+
+.result-json {
+  margin: 0;
+  font-size: 12px;
+  color: #1e293b;
+  font-family: 'Courier New', monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* Transition */
+.result-fade-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.result-fade-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
+}
+</style>

--- a/apps/sample-vue-full/views/Demo/DemoSignPad.vue
+++ b/apps/sample-vue-full/views/Demo/DemoSignPad.vue
@@ -1,34 +1,134 @@
 <template>
-  <div class="container">
-    <h1>Sign Pad Custom Element</h1>
-    <vcxwc-sign-pad
-      width="200"
-      height="200"
-      v-model="imageDataUrl"
-      context2d='{ "lineWidth": 2, "strokeStyle": "#00f" }'
-    ></vcxwc-sign-pad>
-    <p><button type="button" @click="signDataFn">See Signature Data</button></p>
+  <div class="demo-signpad">
+    <a-row :gutter="[16, 16]">
+
+      <!-- Full signature — wide landscape canvas, thin black ink -->
+      <a-col :xs="24" :lg="16">
+        <SignaturePad
+          v-model="signature1"
+          title="Full Signature"
+          :width="420"
+          :height="150"
+          :line-width="2"
+          stroke-style="#1e293b"
+          background-color="#ffffff"
+          @update:model-value="onSign1"
+        />
+      </a-col>
+
+      <!-- Initials / Paraf — small square canvas, thicker indigo ink -->
+      <a-col :xs="24" :lg="8">
+        <SignaturePad
+          v-model="signature2"
+          title="Initials / Paraf"
+          :width="150"
+          :height="150"
+          :line-width="3"
+          stroke-style="#4f46e5"
+          background-color="#f5f3ff"
+          @update:model-value="onSign2"
+        />
+      </a-col>
+
+      <!-- Log card -->
+      <a-col :span="24">
+        <a-card :bordered="false" class="log-card">
+          <template #title>
+            <div class="card-title-row">
+              <FileTextOutlined class="card-title-icon" />
+              <span>Signature Log</span>
+              <a-badge :count="log.length" :number-style="{ background: '#4f46e5' }" />
+            </div>
+          </template>
+          <template #extra>
+            <a-button v-if="log.length" type="text" size="small" danger @click="log = []">
+              Clear All
+            </a-button>
+          </template>
+
+          <a-empty v-if="!log.length" description="No signatures recorded yet" :image="Empty.PRESENTED_IMAGE_SIMPLE" />
+
+          <a-list v-else size="small" :data-source="log" :split="true">
+            <template #renderItem="{ item, index }">
+              <a-list-item>
+                <a-list-item-meta>
+                  <template #avatar>
+                    <a-image :src="item.dataUrl" :width="60" :height="30" :preview="false" style="border-radius:4px;border:1px solid #e2e8f0;object-fit:contain" />
+                  </template>
+                  <template #title>{{ item.source }}</template>
+                  <template #description>{{ item.time }}</template>
+                </a-list-item-meta>
+                <template #actions>
+                  <a-tag :color="item.color" style="font-size:11px">{{ item.tag }}</a-tag>
+                </template>
+              </a-list-item>
+            </template>
+          </a-list>
+        </a-card>
+      </a-col>
+
+    </a-row>
   </div>
 </template>
 
 <script setup>
-import '@common/web/sign-pad.js';
-import { onMounted, ref } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: icons and components used in Vue template
+import { FileTextOutlined } from '@ant-design/icons-vue';
+import { Empty } from 'ant-design-vue';
+import { ref } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: component used in Vue template
+import SignaturePad from '../../components/SignaturePad.vue';
 
-const imageDataUrl = ref('');
+const signature1 = ref('');
+const signature2 = ref('');
+const log = ref([]);
 
-onMounted(async () => {
-  console.log('Demo Signpad');
-});
-
-const signDataFn = e => {
-  alert('see console log for signature data');
-  console.log('imageDataUrl', imageDataUrl.value);
+const addLog = (dataUrl, source, tag, color) => {
+  if (!dataUrl) return;
+  log.value.unshift({
+    dataUrl,
+    source,
+    tag,
+    color,
+    time: new Date().toLocaleTimeString(),
+  });
 };
+
+const onSign1 = val => addLog(val, 'Full Signature', 'Signature', 'default');
+const onSign2 = val => addLog(val, 'Initials / Paraf', 'Initials', 'purple');
 </script>
 
 <style scoped>
-vcxwc-sign-pad {
-  --vcxwc-sign-pad-background-color: #faa;
+.demo-signpad {
+  font-family: 'DM Sans', sans-serif;
+}
+
+:deep(.log-card) {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+:deep(.log-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.log-card .ant-card-body) {
+  padding: 16px 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
 }
 </style>

--- a/apps/sample-vue-full/views/Demo/DemoSignPad.vue
+++ b/apps/sample-vue-full/views/Demo/DemoSignPad.vue
@@ -74,6 +74,7 @@
 <script setup>
 // biome-ignore lint/correctness/noUnusedImports: icons and components used in Vue template
 import { FileTextOutlined } from '@ant-design/icons-vue';
+// biome-ignore lint/correctness/noUnusedImports: Empty.PRESENTED_IMAGE_SIMPLE used in template
 import { Empty } from 'ant-design-vue';
 import { ref } from 'vue';
 // biome-ignore lint/correctness/noUnusedImports: component used in Vue template

--- a/apps/sample-vue-full/views/Demo/DemoTest.vue
+++ b/apps/sample-vue-full/views/Demo/DemoTest.vue
@@ -1,137 +1,208 @@
 <template>
-  <div class="container">
-    <h1>Site A - Test VueJS 3</h1>
-    <!-- <div v-for="(item, i) in list" :key="i" :ref="(el) => { divs[i] = el }"> -->
-    <!-- <div v-for="(item, i) in list" :key="i" :ref="(el) => makeRef(el, i)"> -->
-    <div v-for="(item, i) in list" :key="i" :ref="(el) => (divs[i] = el)">{{ item }}</div>
-    <div class="section">
-      <div class="box" style="background-color: red">A</div>
-      <div class="box" style="background-color: lightblue">B</div>
-      <div class="box" style="background-color: yellow">C</div>
-      <div class="box" style="background-color: brown">D</div>
-      <div class="box" style="background-color: lightgreen">E</div>
-      <div class="box" style="background-color: red">A</div>
-      <div class="box" style="background-color: brown">G</div>
-    </div>
+  <div class="demo-test">
+    <a-row :gutter="[16, 16]">
 
-    <p><button type="button" @click="router.push('/dun-no-what-is-this')">Go an unknown route</button></p>
-    <p>
-      <span>Count is: {{ count }}</span>
-      <button type="button" @click="count++">increment</button>
-    </p>
-    <p>
-      <span>Mock Service Worder Test</span>
-      <button type="button" @click="callMsw">Call MSW Endpoint</button>
-    </p>
-    <p>
-      <button type="button" @click="(e) => testApi('healthcheck')">Test API</button>
-      <button type="button" @click="(e) => testApi('health-auth')">Test API Auth</button>
-    </p>
-    <p>Non-Reactive Data: {{ nonReactiveData }}</p>
-    <p>Reactive Data: {{ reactiveData }}</p>
-    <p>
-      Vuex Store: {{ store.user }}
-      <button type="button" @click="(e) => store.updateUser({ id: 'AnewId' })">Change Name</button>
-    </p>
-    <h2>Test Reactivity In Object</h2>
-    <p>
-      Click to see increment. Also check console.log if onUpdated is called
-      <button type="button" @click="() => testObjectRef.a++">Test Object Ref = {{ testObjectRef.a }}</button>
-      <button type="button" @click="() => testObjectReactive.a.xx++">
-        Test Object Reactive = {{ testObjectReactive.a.xx }}
-      </button>
-    </p>
-    <ul>
-      <li v-for="n in 10" :key="n">{{ n }}</li>
-    </ul>
+      <!-- Template Refs -->
+      <a-col :span="24">
+        <a-card :bordered="false" class="test-card">
+          <template #title>
+            <div class="card-title-row">
+              <AppstoreOutlined class="card-title-icon" />
+              <span>Template Refs & Flex Layout</span>
+            </div>
+          </template>
+          <p class="test-desc">
+            Items rendered via <code>v-for</code> with inline <code>:ref</code> binding.
+          </p>
+          <div class="ref-list">
+            <a-tag v-for="(item, i) in list" :key="i" :ref="(el) => (divs[i] = el)" color="purple">
+              {{ item }}
+            </a-tag>
+          </div>
+          <a-divider style="margin: 16px 0" />
+          <div class="box-row">
+            <ColorBox v-for="box in boxes" :key="box.label" :color="box.color" :label="box.label" />
+          </div>
+        </a-card>
+      </a-col>
+
+      <!-- Counter & Store -->
+      <a-col :xs="24" :lg="12">
+        <a-card :bordered="false" class="test-card">
+          <template #title>
+            <div class="card-title-row">
+              <SyncOutlined class="card-title-icon" />
+              <span>Counter & Store</span>
+            </div>
+          </template>
+
+          <div class="test-row">
+            <span class="test-label">Count</span>
+            <a-space>
+              <a-tag color="blue" style="font-size:14px;padding:4px 12px">{{ count }}</a-tag>
+              <a-button size="small" type="primary" @click="count++">
+                <template #icon><PlusOutlined /></template>
+                Increment
+              </a-button>
+            </a-space>
+          </div>
+
+          <a-divider style="margin: 12px 0" />
+
+          <div class="test-row">
+            <span class="test-label">Non-reactive</span>
+            <a-tag>{{ nonReactiveData }}</a-tag>
+          </div>
+          <div class="test-row">
+            <span class="test-label">Reactive</span>
+            <a-tag color="green">{{ reactiveData }}</a-tag>
+          </div>
+
+          <a-divider style="margin: 12px 0" />
+
+          <div class="test-row">
+            <span class="test-label">Store user</span>
+            <a-tag color="purple">{{ store.user?.id ?? 'null' }}</a-tag>
+          </div>
+          <a-button size="small" style="margin-top:8px" @click="store.updateUser({ id: 'AnewId' })">
+            Change Store User ID
+          </a-button>
+        </a-card>
+      </a-col>
+
+      <!-- Object Reactivity -->
+      <a-col :xs="24" :lg="12">
+        <a-card :bordered="false" class="test-card">
+          <template #title>
+            <div class="card-title-row">
+              <ApiOutlined class="card-title-icon" />
+              <span>Object Reactivity</span>
+            </div>
+          </template>
+          <p class="test-desc">Click to increment. Check console for <code>onUpdated</code> calls.</p>
+
+          <div class="test-row">
+            <span class="test-label">ref({ a })</span>
+            <a-space>
+              <a-tag color="orange" style="font-size:14px;padding:4px 12px">{{ testObjectRef.a }}</a-tag>
+              <a-button size="small" @click="testObjectRef.a++">
+                <template #icon><PlusOutlined /></template>
+                ref.a++
+              </a-button>
+            </a-space>
+          </div>
+
+          <a-divider style="margin: 12px 0" />
+
+          <div class="test-row">
+            <span class="test-label">reactive({ a.xx })</span>
+            <a-space>
+              <a-tag color="cyan" style="font-size:14px;padding:4px 12px">{{ testObjectReactive.a.xx }}</a-tag>
+              <a-button size="small" @click="testObjectReactive.a.xx++">
+                <template #icon><PlusOutlined /></template>
+                reactive.a.xx++
+              </a-button>
+            </a-space>
+          </div>
+
+          <a-divider style="margin: 12px 0" />
+
+          <a-button
+            size="small"
+            type="dashed"
+            @click="router.push('/dun-no-what-is-this')"
+          >
+            Navigate to unknown route →
+          </a-button>
+        </a-card>
+      </a-col>
+
+      <!-- API Tests -->
+      <a-col :span="24">
+        <a-card :bordered="false" class="test-card">
+          <template #title>
+            <div class="card-title-row">
+              <CloudOutlined class="card-title-icon" />
+              <span>API & MSW Tests</span>
+            </div>
+          </template>
+
+          <a-space wrap>
+            <a-button type="primary" :loading="apiLoading === 'healthcheck'" @click="testApi('healthcheck')">
+              <template #icon><PlayCircleOutlined /></template>
+              Health Check
+            </a-button>
+            <a-button :loading="apiLoading === 'health-auth'" @click="testApi('health-auth')">
+              <template #icon><PlayCircleOutlined /></template>
+              Health Auth
+            </a-button>
+            <a-button type="dashed" :loading="apiLoading === 'msw'" @click="callMsw">
+              <template #icon><PlayCircleOutlined /></template>
+              MSW Endpoint
+            </a-button>
+          </a-space>
+
+          <Transition name="result-fade">
+            <div v-if="apiResult" class="api-result">
+              <a-tag :color="apiResult.ok ? 'green' : 'red'" style="margin-bottom:6px">
+                {{ apiResult.ok ? '200 OK' : 'Error' }}
+              </a-tag>
+              <pre class="api-json">{{ JSON.stringify(apiResult.data, null, 2) }}</pre>
+            </div>
+          </Transition>
+        </a-card>
+      </a-col>
+
+    </a-row>
   </div>
 </template>
 
 <script setup>
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
+import {
+  ApiOutlined,
+  AppstoreOutlined,
+  CloudOutlined,
+  PlayCircleOutlined,
+  PlusOutlined,
+  SyncOutlined,
+} from '@ant-design/icons-vue';
 import { http } from '@common/vue/plugins/fetch.js';
-// NOSONAR unref, toRef, toRefs, isRef, isProxy, isReactive, isReadonly, defineComponent, getCurrentInstance, reactive, readonly, watch, watchEffect
 import { onBeforeUnmount, onBeforeUpdate, onMounted, onUnmounted, onUpdated, reactive, ref } from 'vue';
 import { useRouter } from 'vue-router';
+// biome-ignore lint/correctness/noUnusedImports: component used in Vue template
+import ColorBox from '../../components/ColorBox.vue';
 import { useMainStore } from '../../store.js';
 
 const list = reactive([1, 2, 3]);
 const divs = ref([]);
-// const route = useRoute()
 const router = useRouter();
-// const obj = reactive({ count: 0 })
 const store = useMainStore();
 const count = ref(0);
 let nonReactiveData = 10;
 const reactiveData = ref(20);
-const searchRef = ref(null);
-const searchVal = ref('');
-const searchResult = ref('');
 const testObjectRef = ref({ a: 10, b: 20, c: 30 });
 const testObjectReactive = reactive({ a: { xx: 40 }, b: 50, c: 60 });
+const apiLoading = ref('');
+const apiResult = ref(null);
 
-// NOSONAR
-// const plusOne = computed(() => count.value + 1)
-// const stop = watchEffect(() => console.log(count.value))
-// // -> logs 0
-// setTimeout(() => {
-//   count.value++
-//   // -> logs 1
-// }, 100)
-// // stop()
-//
-// put watchEffect inside onMounted to have access to DOM
-// // watching a getter
-// const state = reactive({ count: 0 })
-// watch(
-//   () => state.count,
-//   (count, prevCount) => {
-//   }
-// )
-//
-// // directly watching a ref
-// const count = ref(0)
-// watch(search, (newVal, prevVal) => {
-//   console.log('watch search', newVal)
-// })
-//
-// // Watch prop value change and assign to value 'selected' Ref
-// watch(() => props.value, (newValue: Props['value']) => {
-//   selected.value = newValue;
-// });
-//
-// watch([fooRef, barRef], ([foo, bar], [prevFoo, prevBar]) => {
-// })
-//
-// watch(
-//   () => object_or_primitive_being_watched,
-//   (state, prevState) => {
-//     console.log(
-//       "deep ",
-//       state.attributes.name,
-//       prevState.attributes.name
-//     );
-//   },
-//   { deep: true }
-// )
-// watchEffect ... ?
+const boxes = [
+  { color: '#ef4444', label: 'A' },
+  { color: '#60a5fa', label: 'B' },
+  { color: '#fbbf24', label: 'C' },
+  { color: '#92400e', label: 'D' },
+  { color: '#4ade80', label: 'E' },
+  { color: '#f87171', label: 'A' },
+  { color: '#a16207', label: 'G' },
+];
 
-// make sure to reset the refs before each update
 onBeforeUpdate(() => {
   divs.value = [];
 });
-const makeRef = (el, i) => {
-  divs[i] = el;
-};
+
 let timerId;
 onMounted(async () => {
   console.log('demomain mounted!');
-  // NOSONAR
-  // console.log('props', props)
-  // console.log('context', context)
-  // console.log('useStore', store)
-  // console.log('useRouter', router)
-  // console.log('useRoute', route)
-
   timerId = setInterval(() => {
     console.log('timer fired');
     nonReactiveData += 1;
@@ -140,47 +211,138 @@ onMounted(async () => {
 });
 onBeforeUnmount(() => {
   if (timerId) clearInterval(timerId);
-  // / console.log('demomain before unmount!')
 });
 onUpdated(() => console.log('demomain updated!'));
 onUnmounted(() => console.log('demomain unmounted!'));
 
-const testApi = async test => {
+const testApi = async endpoint => {
+  apiLoading.value = endpoint;
+  apiResult.value = null;
   try {
-    const { data } = await http.get(`/api/${test}`);
-    console.log('testApi', data);
+    const { data } = await http.get(`/api/${endpoint}`);
+    apiResult.value = { ok: true, data };
   } catch (e) {
-    console.log('testApi err', e);
+    apiResult.value = { ok: false, data: e?.data || e.toString() };
   }
+  apiLoading.value = '';
 };
 
-const callMsw = async test => {
+const callMsw = async () => {
+  apiLoading.value = 'msw';
+  apiResult.value = null;
   try {
     const { data } = await http.get('/api/msw/test');
-    alert(`MSA returned: ${data.message.toString()}`);
+    apiResult.value = { ok: true, data };
   } catch (e) {
-    console.log('callMsw err', e);
+    apiResult.value = { ok: false, data: e?.data || e.toString() };
   }
+  apiLoading.value = '';
 };
 </script>
 
-<style lang="css" scoped>
-.section {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: center;
-  align-content: space-around;
+<style scoped>
+.demo-test {
+  font-family: 'DM Sans', sans-serif;
 }
 
-.box {
-  width: 200px;
-  /* border: 3px solid rgba(0,0,0,.2); */
-  /* flex: 1 0 21%; */
-  /* width: 25%; */
-  margin: 5px;
-  height: 100px;
-  background-color: blue;
+:deep(.test-card) {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+:deep(.test-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.test-card .ant-card-body) {
+  padding: 16px 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+.test-desc {
+  font-size: 13px;
+  color: #64748b;
+  margin: 0 0 12px;
+}
+
+.test-desc code {
+  background: #f1f5f9;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: #4f46e5;
+}
+
+/* Ref list */
+.ref-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Box row */
+.box-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+/* Test rows */
+.test-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.test-label {
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+  min-width: 120px;
+}
+
+/* API result */
+.api-result {
+  margin-top: 16px;
+  padding: 12px 14px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+}
+
+.api-json {
+  margin: 0;
+  font-size: 12px;
+  color: #1e293b;
+  font-family: 'Courier New', monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* Transition */
+.result-fade-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.result-fade-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
 }
 </style>

--- a/apps/sample-vue-full/views/Demo/DemoWebCam.vue
+++ b/apps/sample-vue-full/views/Demo/DemoWebCam.vue
@@ -1,25 +1,123 @@
 <template>
-  <div class="container">
-    <h1>Web Cam Custom Element</h1>
-    <vcxwc-web-cam @snap="snappedFn" width="320" height="240">
-      <button type="button" slot="button-snap" class="button" id="snap">Take Photo</button>
-      <button type="button" slot="button-unsnap" class="button" id="unsnap">Start Camera</button>
-    </vcxwc-web-cam>
+  <div class="demo-webcam">
+    <a-row :gutter="[16, 16]">
+      <a-col :xs="24" :lg="14">
+        <WebCamCapture
+          title="Live Camera"
+          :width="320"
+          :height="240"
+          @snap="onSnap"
+        />
+      </a-col>
+
+      <a-col :xs="24" :lg="10">
+        <a-card :bordered="false" class="log-card">
+          <template #title>
+            <div class="card-title-row">
+              <FileImageOutlined class="card-title-icon" />
+              <span>Snap Log</span>
+              <a-badge :count="log.length" :number-style="{ background: '#4f46e5' }" />
+            </div>
+          </template>
+          <template #extra>
+            <a-button v-if="log.length" type="text" size="small" danger @click="log = []">
+              Clear
+            </a-button>
+          </template>
+
+          <div v-if="!log.length" class="log-empty">
+            <a-empty description="No photos taken yet" :image="Empty.PRESENTED_IMAGE_SIMPLE" />
+          </div>
+
+          <a-list v-else size="small" :data-source="log" :split="true">
+            <template #renderItem="{ item, index }">
+              <a-list-item class="log-item">
+                <a-list-item-meta>
+                  <template #avatar>
+                    <a-image :src="item.thumb" :width="48" :height="36" :preview="false" style="border-radius:6px;object-fit:cover" />
+                  </template>
+                  <template #title>Photo {{ log.length - index }}</template>
+                  <template #description>{{ item.time }}</template>
+                </a-list-item-meta>
+              </a-list-item>
+            </template>
+          </a-list>
+        </a-card>
+      </a-col>
+    </a-row>
   </div>
 </template>
 
-<script>
-import '@common/web/web-cam.js';
+<script setup>
+// biome-ignore lint/correctness/noUnusedImports: icons and components used in Vue template
+import { FileImageOutlined } from '@ant-design/icons-vue';
+import { Empty } from 'ant-design-vue';
+import { ref } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: component used in Vue template
+import WebCamCapture from '../../components/WebCamCapture.vue';
 
-const snappedFn = e => {
-  alert('see console log for snapped picture data');
-  console.log('snappedFn', e.detail);
+const log = ref([]);
+
+const onSnap = dataUrl => {
+  log.value.unshift({
+    thumb: dataUrl,
+    time: new Date().toLocaleTimeString(),
+  });
 };
 </script>
 
 <style scoped>
-vcxwc-web-cam {
-  --vcxwc-web-cam-top: 5%;
-  --vcxwc-web-cam-right: 5%;
+.demo-webcam {
+  font-family: 'DM Sans', sans-serif;
+}
+
+:deep(.log-card) {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  height: 100%;
+}
+
+:deep(.log-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.log-card .ant-card-body) {
+  padding: 16px 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+.log-empty {
+  padding: 24px 0;
+}
+
+:deep(.log-item.ant-list-item) {
+  padding: 10px 0;
+}
+
+:deep(.log-item .ant-list-item-meta-title) {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 2px;
+}
+
+:deep(.log-item .ant-list-item-meta-description) {
+  font-size: 12px;
+  color: #64748b;
 }
 </style>

--- a/apps/sample-vue-full/views/Demo/DemoWebCam.vue
+++ b/apps/sample-vue-full/views/Demo/DemoWebCam.vue
@@ -51,6 +51,7 @@
 <script setup>
 // biome-ignore lint/correctness/noUnusedImports: icons and components used in Vue template
 import { FileImageOutlined } from '@ant-design/icons-vue';
+// biome-ignore lint/correctness/noUnusedImports: Empty.PRESENTED_IMAGE_SIMPLE used in template
 import { Empty } from 'ant-design-vue';
 import { ref } from 'vue';
 // biome-ignore lint/correctness/noUnusedImports: component used in Vue template

--- a/apps/sample-vue-full/views/Demo/Filler.vue
+++ b/apps/sample-vue-full/views/Demo/Filler.vue
@@ -1,45 +1,176 @@
 <template>
-  <div class="container">
-    <h1>Filler Test Page</h1>
-    <p>Props Id {{ testId }}</p>
-    <p>Route Param: {{ routeParam }}</p>
-    <a-button v-if="!routeParam" @click="$router.push(`${$route.path}/111`)">Set Param</a-button>
-    <a-button v-else @click="$router.back()">Back</a-button>
-    <hr>
-    <p>Show a long list to test scrolling</p>
-    <ul>
-      <li v-for="n in 50" :key="n">{{ n }}</li>
-    </ul>
+  <div class="demo-filler">
+    <a-row :gutter="[16, 16]">
+
+      <!-- Header card -->
+      <a-col :span="24">
+        <a-card :bordered="false" class="filler-card">
+          <template #title>
+            <div class="card-title-row">
+              <ExperimentOutlined class="card-title-icon" />
+              <span>Filler Test Page</span>
+            </div>
+          </template>
+          <template #extra>
+            <a-button v-if="!routeParam" type="primary" size="small" @click="setParam">
+              <template #icon><LinkOutlined /></template>
+              Set Param
+            </a-button>
+            <a-button v-else size="small" @click="$router.back()">
+              <template #icon><ArrowLeftOutlined /></template>
+              Back
+            </a-button>
+          </template>
+
+          <a-descriptions :column="{ xs: 1, sm: 2 }" size="small" :bordered="false">
+            <a-descriptions-item label="Prop testId">
+              <a-tag :color="testId === -1 ? 'default' : 'purple'">{{ testId }}</a-tag>
+            </a-descriptions-item>
+            <a-descriptions-item label="Route Param">
+              <a-tag :color="routeParam ? 'blue' : 'default'">{{ routeParam || 'none' }}</a-tag>
+            </a-descriptions-item>
+            <a-descriptions-item label="Full Path">
+              <code class="path-code">{{ $route.fullPath }}</code>
+            </a-descriptions-item>
+            <a-descriptions-item label="Route Name">
+              <a-tag color="green">{{ $route.name }}</a-tag>
+            </a-descriptions-item>
+          </a-descriptions>
+        </a-card>
+      </a-col>
+
+      <!-- Scroll list card -->
+      <a-col :span="24">
+        <a-card :bordered="false" class="filler-card">
+          <template #title>
+            <div class="card-title-row">
+              <UnorderedListOutlined class="card-title-icon" />
+              <span>Scroll Test List</span>
+              <a-badge
+                :count="50"
+                :number-style="{ background: '#4f46e5' }"
+                style="margin-left:auto"
+              />
+            </div>
+          </template>
+          <p class="hint-text">A long list to test layout scrolling behaviour within the secure layout.</p>
+
+          <a-list :data-source="items" :grid="{ gutter: 12, xs: 2, sm: 3, md: 4, lg: 5, xl: 6 }">
+            <template #renderItem="{ item }">
+              <a-list-item>
+                <a-card :bordered="false" hoverable class="item-card">
+                  <div class="item-number">{{ item }}</div>
+                  <div class="item-label">Item</div>
+                </a-card>
+              </a-list-item>
+            </template>
+          </a-list>
+        </a-card>
+      </a-col>
+
+    </a-row>
   </div>
 </template>
 
 <script setup>
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
+import { ArrowLeftOutlined, ExperimentOutlined, LinkOutlined, UnorderedListOutlined } from '@ant-design/icons-vue';
 import { ref } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 const props = defineProps({
-  testId: {
-    type: Number,
-    default: -1,
-  },
+  testId: { type: Number, default: -1 },
 });
 
 const route = useRoute();
+const router = useRouter();
 const routeParam = ref(route.params.param);
-console.log('props', props);
-console.log('route', route);
 
-// TODELETE
-// export default {
-//   name: 'DemoFiller',
-//   props: {
-//   },
-//   setup(props, context) {
-//     // console.log('Filler props', props, context)
-//     return {
-//       props,
-//       routeParam
-//     }
-//   }
-// }
+const items = Array.from({ length: 50 }, (_, i) => i + 1);
+
+const setParam = () => router.push(`${route.path}/111`);
 </script>
+
+<style scoped>
+.demo-filler {
+  font-family: 'DM Sans', sans-serif;
+}
+
+.filler-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+:deep(.filler-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.filler-card .ant-card-body) {
+  padding: 16px 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  width: 100%;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+:deep(.ant-descriptions-item-label) {
+  font-size: 12px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+:deep(.ant-descriptions-item-content) {
+  font-size: 12px;
+}
+
+.path-code {
+  font-size: 11px;
+  background: #f1f5f9;
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: #4f46e5;
+}
+
+.hint-text {
+  font-size: 13px;
+  color: #64748b;
+  margin: 0 0 16px;
+}
+
+/* Grid items */
+.item-card {
+  border-radius: 10px;
+  background: #f8fafc;
+  text-align: center;
+}
+
+:deep(.item-card .ant-card-body) {
+  padding: 12px 8px;
+}
+
+.item-number {
+  font-size: 20px;
+  font-weight: 700;
+  color: #4f46e5;
+  line-height: 1.2;
+}
+
+.item-label {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-top: 2px;
+}
+</style>

--- a/apps/sample-vue-full/views/Favv/DemoCascade2Api.vue
+++ b/apps/sample-vue-full/views/Favv/DemoCascade2Api.vue
@@ -466,7 +466,7 @@ const onClear = () => {
 
 .field-hint {
   font-size: 11px;
-  color: #94a3b8;
+  color: #475569;
   margin-top: 4px;
 }
 
@@ -514,7 +514,7 @@ const onClear = () => {
 
 .endpoint-desc {
   font-size: 11px;
-  color: #94a3b8;
+  color: #475569;
   margin-top: 2px;
 }
 

--- a/apps/sample-vue-full/views/Favv/DemoCascade2Api.vue
+++ b/apps/sample-vue-full/views/Favv/DemoCascade2Api.vue
@@ -452,7 +452,7 @@ const onClear = () => {
 
 :deep(.ant-form-item-label > label) {
   font-size: 13px;
-  color: #64748b;
+  color: #475569;
   font-weight: 500;
 }
 
@@ -460,7 +460,7 @@ const onClear = () => {
   display: flex;
   align-items: center;
   font-size: 13px;
-  color: #64748b;
+  color: #475569;
   font-weight: 500;
 }
 
@@ -482,7 +482,7 @@ const onClear = () => {
 
 :deep(.mini-stat .ant-statistic-title) {
   font-size: 11px;
-  color: #64748b;
+  color: #475569;
   font-weight: 500;
   margin-bottom: 2px;
 }
@@ -523,7 +523,7 @@ const onClear = () => {
   padding: 0 4px;
   border-radius: 3px;
   font-size: 11px;
-  color: #64748b;
+  color: #475569;
 }
 
 /* Result box */

--- a/apps/sample-vue-full/views/Favv/DemoCascade2Api.vue
+++ b/apps/sample-vue-full/views/Favv/DemoCascade2Api.vue
@@ -1,107 +1,556 @@
 <template>
-  <a-form :model="formState" layout="vertical">
-    <a-form-item label="Continents">
-      <a-checkbox @change="onCheckAllChange">Select all</a-checkbox>
-      <!-- v-model:checked="checkAll" -->
-      <a-select
-        mode="multiple"
-        placeholder="Please select"
-        v-model:value="formState.continents"
-        @blur="blurSelect"
-        @deselect="blurSelect"
-      >
-        <template #clearIcon><setting-outlined /></template>
-        <a-select-option v-for="item in formState.continentsList" :key="item">{{ item }}</a-select-option>
-      </a-select>
-    </a-form-item>
+  <div class="demo-cascade-api">
+    <a-row :gutter="[16, 16]">
 
-    <a-form-item label="Countries East Hemisphere">
-      <a-select mode="multiple" placeholder="Please select" v-model:value="formState.countriesEast" allow-clear>
-        <a-select-option v-for="item in formState.countriesEastList" :key="item">{{ item }}</a-select-option>
-      </a-select>
-    </a-form-item>
-    <a-form-item label="Countries West Hemisphere">
-      <a-select
-        mode="multiple"
-        placeholder="Please select"
-        v-model:value="formState.countriesWest"
-        allow-clear
-        @blur="blurSelect2"
-        @deselect="blurSelect2"
-      >
-        <a-select-option v-for="item in formState.countriesWestList" :key="item">{{ item }}</a-select-option>
-      </a-select>
-    </a-form-item>
+      <!-- LEFT: Cascade Form -->
+      <a-col :xs="24" :lg="15">
+        <a-card :bordered="false" class="cascade-card">
+          <template #title>
+            <div class="card-title-row">
+              <CloudServerOutlined class="card-title-icon" />
+              <span>API-Driven Geography Cascade</span>
+              <a-badge
+                v-if="apiError"
+                status="error"
+                text="API error"
+                style="margin-left:auto;font-size:12px"
+              />
+              <a-badge
+                v-else-if="loadingContinents"
+                status="processing"
+                text="Loading…"
+                style="margin-left:auto;font-size:12px"
+              />
+              <a-badge
+                v-else
+                status="success"
+                text="Connected"
+                style="margin-left:auto;font-size:12px"
+              />
+            </div>
+          </template>
 
-    <a-form-item label="Country States (West)">
-      <a-select mode="multiple" placeholder="Please select" v-model:value="formState.westCountryStates">
-        <a-select-option v-for="item in formState.westCountryStatesList" :key="item">{{ item }}</a-select-option>
-      </a-select>
-    </a-form-item>
+          <a-spin :spinning="loadingContinents" tip="Loading continents…">
+            <a-form :model="formState" layout="vertical">
 
-    <a-form-item> <a-button type="primary" @click="onSubmit">Run</a-button> </a-form-item>
-  </a-form>
+              <!-- Continents -->
+              <a-form-item name="continents">
+                <template #label>
+                  <div class="field-label-row">
+                    <span>Continents</span>
+                    <a-checkbox
+                      :checked="allContinentsSelected"
+                      :indeterminate="someContinentsSelected"
+                      :disabled="!formState.continentsList.length"
+                      style="margin-left:12px"
+                      @change="onCheckAllChange"
+                    >
+                      Select all
+                    </a-checkbox>
+                  </div>
+                </template>
+                <a-select
+                  v-model:value="formState.continents"
+                  mode="multiple"
+                  placeholder="Select continents"
+                  allow-clear
+                  :max-tag-count="6"
+                  :loading="loadingContinents"
+                  @blur="blurSelect"
+                  @deselect="blurSelect"
+                  @clear="blurSelect"
+                >
+                  <a-select-option v-for="item in formState.continentsList" :key="item">{{ item }}</a-select-option>
+                </a-select>
+                <div class="field-hint">Options loaded from API on mount.</div>
+              </a-form-item>
+
+              <a-divider style="margin: 4px 0 16px">
+                <a-tag color="blue" style="font-size:11px">
+                  <template #icon><ApiOutlined /></template>
+                  Driven by Continents API
+                </a-tag>
+              </a-divider>
+
+              <!-- East / West Countries -->
+              <a-spin :spinning="loadingCountries" tip="Fetching countries…">
+                <a-row :gutter="12">
+                  <a-col :xs="24" :sm="12">
+                    <a-form-item label="Countries — East Hemisphere" name="countriesEast">
+                      <a-select
+                        v-model:value="formState.countriesEast"
+                        mode="multiple"
+                        placeholder="Asia, Europe, Africa, ME"
+                        allow-clear
+                        :disabled="!formState.countriesEastList.length"
+                        :max-tag-count="4"
+                      >
+                        <a-select-option v-for="item in formState.countriesEastList" :key="item">
+                          {{ item }}
+                        </a-select-option>
+                      </a-select>
+                    </a-form-item>
+                  </a-col>
+                  <a-col :xs="24" :sm="12">
+                    <a-form-item label="Countries — West Hemisphere" name="countriesWest">
+                      <a-select
+                        v-model:value="formState.countriesWest"
+                        mode="multiple"
+                        placeholder="NA, SA"
+                        allow-clear
+                        :disabled="!formState.countriesWestList.length"
+                        :max-tag-count="4"
+                        @blur="blurSelect2"
+                        @deselect="blurSelect2"
+                        @clear="blurSelect2"
+                      >
+                        <a-select-option v-for="item in formState.countriesWestList" :key="item">
+                          {{ item }}
+                        </a-select-option>
+                      </a-select>
+                    </a-form-item>
+                  </a-col>
+                </a-row>
+              </a-spin>
+
+              <a-divider style="margin: 4px 0 16px">
+                <a-tag color="cyan" style="font-size:11px">
+                  <template #icon><ApiOutlined /></template>
+                  Driven by West Countries API
+                </a-tag>
+              </a-divider>
+
+              <!-- States -->
+              <a-spin :spinning="loadingStates" tip="Fetching states…">
+                <a-form-item label="Country States (West)" name="westCountryStates">
+                  <a-select
+                    v-model:value="formState.westCountryStates"
+                    mode="multiple"
+                    placeholder="Select west countries first"
+                    allow-clear
+                    :disabled="!formState.westCountryStatesList.length"
+                    :max-tag-count="6"
+                  >
+                    <a-select-option v-for="item in formState.westCountryStatesList" :key="item">
+                      {{ item }}
+                    </a-select-option>
+                  </a-select>
+                </a-form-item>
+              </a-spin>
+
+              <a-divider style="margin: 4px 0 16px" />
+
+              <a-form-item style="margin-bottom:0">
+                <a-space>
+                  <a-button
+                    type="primary"
+                    :loading="submitting"
+                    :disabled="!formState.continents.length"
+                    @click="onSubmit"
+                  >
+                    <template #icon><PlayCircleOutlined /></template>
+                    Run
+                  </a-button>
+                  <a-button @click="onClear">Clear All</a-button>
+                </a-space>
+              </a-form-item>
+            </a-form>
+          </a-spin>
+
+          <!-- API error alert -->
+          <Transition name="result-fade">
+            <a-alert
+              v-if="apiError"
+              :message="apiError"
+              type="error"
+              show-icon
+              closable
+              style="margin-top:16px"
+              @close="apiError = ''"
+            />
+          </Transition>
+
+          <!-- Submit result -->
+          <Transition name="result-fade">
+            <div v-if="submitResult" class="result-box">
+              <a-tag color="green" style="margin-bottom:6px">Result</a-tag>
+              <pre class="result-json">{{ submitResult }}</pre>
+            </div>
+          </Transition>
+        </a-card>
+      </a-col>
+
+      <!-- RIGHT: Summary -->
+      <a-col :xs="24" :lg="9">
+        <a-row :gutter="[0, 16]">
+
+          <!-- Stats -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="cascade-card">
+              <a-row>
+                <a-col :span="8" class="mini-stat">
+                  <a-statistic
+                    title="Continents"
+                    :value="formState.continents.length"
+                    :value-style="{ color: '#4f46e5', fontSize: '22px', fontWeight: 700 }"
+                  />
+                </a-col>
+                <a-col :span="8" class="mini-stat">
+                  <a-statistic
+                    title="Countries"
+                    :value="totalCountries"
+                    :value-style="{ color: '#0891b2', fontSize: '22px', fontWeight: 700 }"
+                  />
+                </a-col>
+                <a-col :span="8" class="mini-stat">
+                  <a-statistic
+                    title="States"
+                    :value="formState.westCountryStates.length"
+                    :value-style="{ color: '#16a34a', fontSize: '22px', fontWeight: 700 }"
+                  />
+                </a-col>
+              </a-row>
+            </a-card>
+          </a-col>
+
+          <!-- Selection tree -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="cascade-card">
+              <template #title>
+                <div class="card-title-row">
+                  <UnorderedListOutlined class="card-title-icon" />
+                  <span>Selection Tree</span>
+                </div>
+              </template>
+
+              <a-empty
+                v-if="!formState.continents.length"
+                description="No continents selected"
+                :image="Empty.PRESENTED_IMAGE_SIMPLE"
+                style="margin: 8px 0"
+              />
+
+              <a-tree
+                v-else
+                :tree-data="selectionTree"
+                default-expand-all
+                :selectable="false"
+                class="selection-tree"
+              />
+            </a-card>
+          </a-col>
+
+          <!-- API endpoints info -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="cascade-card">
+              <template #title>
+                <div class="card-title-row">
+                  <ApiOutlined class="card-title-icon" />
+                  <span>API Endpoints</span>
+                </div>
+              </template>
+
+              <a-timeline>
+                <a-timeline-item color="blue">
+                  <div class="endpoint-row">
+                    <a-tag color="blue" style="font-size:10px;margin-bottom:2px">GET</a-tag>
+                    <code class="endpoint-path">/api/custom-app/cascade/continents</code>
+                  </div>
+                  <div class="endpoint-desc">Returns available continents list</div>
+                </a-timeline-item>
+                <a-timeline-item color="cyan">
+                  <div class="endpoint-row">
+                    <a-tag color="cyan" style="font-size:10px;margin-bottom:2px">GET</a-tag>
+                    <code class="endpoint-path">/api/custom-app/cascade/countries</code>
+                  </div>
+                  <div class="endpoint-desc">Returns east & west country lists filtered by <code>?continents=</code></div>
+                </a-timeline-item>
+                <a-timeline-item color="green">
+                  <div class="endpoint-row">
+                    <a-tag color="green" style="font-size:10px;margin-bottom:2px">GET</a-tag>
+                    <code class="endpoint-path">/api/custom-app/cascade/states</code>
+                  </div>
+                  <div class="endpoint-desc">Returns states filtered by <code>?countries=</code></div>
+                </a-timeline-item>
+              </a-timeline>
+            </a-card>
+          </a-col>
+
+        </a-row>
+      </a-col>
+
+    </a-row>
+  </div>
 </template>
+
 <script setup>
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
+import { ApiOutlined, CloudServerOutlined, PlayCircleOutlined, UnorderedListOutlined } from '@ant-design/icons-vue';
 import { http } from '@common/vue/plugins/fetch.js';
-import { onMounted, reactive, toRaw } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: Empty.PRESENTED_IMAGE_SIMPLE used in template
+import { Empty } from 'ant-design-vue';
+import { computed, onMounted, reactive, ref, toRaw } from 'vue';
 
 const { VITE_API_URL } = import.meta.env;
 
+const loadingContinents = ref(false);
+const loadingCountries = ref(false);
+const loadingStates = ref(false);
+const submitting = ref(false);
+const apiError = ref('');
+const submitResult = ref('');
+
 const formState = reactive({
-  continents: [], // Level 1
+  continents: [],
   continentsList: [],
-  countriesEast: [], // Level 2
+  countriesEast: [],
   countriesEastList: [],
-  countriesWest: [], // Level 2
+  countriesWest: [],
   countriesWestList: [],
-  westCountryStates: [], // Level 3
+  westCountryStates: [],
   westCountryStatesList: [],
 });
 
 onMounted(async () => {
+  loadingContinents.value = true;
   try {
     const { data } = await http.get(`${VITE_API_URL}/api/custom-app/cascade/continents`);
     formState.continentsList = [...data];
   } catch (e) {
-    console.log(e.toString());
+    apiError.value = `Failed to load continents: ${e?.message ?? e.toString()}`;
   }
+  loadingContinents.value = false;
 });
 
+const allContinentsSelected = computed(
+  () => formState.continents.length === formState.continentsList.length && formState.continentsList.length > 0,
+);
+const someContinentsSelected = computed(() => formState.continents.length > 0 && !allContinentsSelected.value);
+
 const onCheckAllChange = e => {
-  if (e.target.checked === true) {
-    formState.continents = [...formState.continentsList];
-    blurSelect(); // select all countriesEast / countriesWest
-  } else {
-    formState.continents = [];
-    blurSelect(); // clear all countriesEast / countriesWest
-  }
+  formState.continents = e.target.checked ? [...formState.continentsList] : [];
+  blurSelect();
 };
 
 const blurSelect = async () => {
-  // get the countries from continent
-  const { data } = await http.get(
-    `${VITE_API_URL}/api/custom-app/cascade/countries?continents=${formState.continents.join(',')}`,
-  );
-  formState.countriesEastList = data.countriesEastList; // update from filteered masterlist in db
-  formState.countriesWestList = data.countriesWestList; // update from filteered masterlist in db
-  formState.countriesWest = formState.countriesWestList.filter(x => formState.countriesWest.includes(x)); // intersection
-  formState.countriesEast = formState.countriesEastList.filter(x => formState.countriesEast.includes(x)); // intersection
-  blurSelect2();
+  loadingCountries.value = true;
+  apiError.value = '';
+  try {
+    const { data } = await http.get(
+      `${VITE_API_URL}/api/custom-app/cascade/countries?continents=${formState.continents.join(',')}`,
+    );
+    formState.countriesEastList = data.countriesEastList;
+    formState.countriesWestList = data.countriesWestList;
+    formState.countriesEast = formState.countriesEastList.filter(x => formState.countriesEast.includes(x));
+    formState.countriesWest = formState.countriesWestList.filter(x => formState.countriesWest.includes(x));
+    await blurSelect2();
+  } catch (e) {
+    apiError.value = `Failed to load countries: ${e?.message ?? e.toString()}`;
+  }
+  loadingCountries.value = false;
 };
 
 const blurSelect2 = async () => {
-  const { data } = await http.get(
-    `${VITE_API_URL}/api/custom-app/cascade/states?countries=${formState.countriesWest.join(',')}`,
-  );
-  formState.westCountryStatesList = data; // update from filteered masterlist in db
-  formState.westCountryStates = formState.westCountryStatesList.filter(x => formState.westCountryStates.includes(x)); // intersection
+  loadingStates.value = true;
+  try {
+    const { data } = await http.get(
+      `${VITE_API_URL}/api/custom-app/cascade/states?countries=${formState.countriesWest.join(',')}`,
+    );
+    formState.westCountryStatesList = data;
+    formState.westCountryStates = formState.westCountryStatesList.filter(x => formState.westCountryStates.includes(x));
+  } catch (e) {
+    apiError.value = `Failed to load states: ${e?.message ?? e.toString()}`;
+  }
+  loadingStates.value = false;
 };
+
+const totalCountries = computed(() => formState.countriesEast.length + formState.countriesWest.length);
+
+const selectionTree = computed(() =>
+  formState.continents.map(continent => {
+    const east = formState.countriesEastList.filter(c => formState.countriesEast.includes(c));
+    const west = formState.countriesWestList.filter(c => formState.countriesWest.includes(c));
+    const allCountries = [...east, ...west];
+    return {
+      title: continent,
+      key: continent,
+      children: allCountries.map(country => ({
+        title: country,
+        key: `${continent}-${country}`,
+        children: formState.westCountryStates
+          .filter(s => formState.westCountryStatesList.includes(s))
+          .map(s => ({ title: s, key: `${continent}-${country}-${s}` })),
+      })),
+    };
+  }),
+);
 
 const onSubmit = async () => {
-  console.log('submit!', toRaw(formState));
+  submitting.value = true;
+  const raw = toRaw(formState);
+  submitResult.value = JSON.stringify(
+    {
+      continents: raw.continents,
+      countriesEast: raw.countriesEast,
+      countriesWest: raw.countriesWest,
+      westCountryStates: raw.westCountryStates,
+    },
+    null,
+    2,
+  );
+  submitting.value = false;
 };
 
-const labelCol = { span: 4 }; // form
-const wrapperCol = { span: 14 };
+const onClear = () => {
+  formState.continents = [];
+  formState.countriesEast = [];
+  formState.countriesEastList = [];
+  formState.countriesWest = [];
+  formState.countriesWestList = [];
+  formState.westCountryStates = [];
+  formState.westCountryStatesList = [];
+  submitResult.value = '';
+  apiError.value = '';
+};
 </script>
+
+<style scoped>
+.demo-cascade-api {
+  font-family: 'DM Sans', sans-serif;
+}
+
+.cascade-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  height: 100%;
+}
+
+:deep(.cascade-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.cascade-card .ant-card-body) {
+  padding: 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  width: 100%;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+:deep(.ant-form-item-label > label) {
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.field-label-row {
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.field-hint {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-top: 4px;
+}
+
+/* Mini stats */
+.mini-stat {
+  padding: 4px 12px;
+  border-right: 1px solid #f1f5f9;
+}
+
+.mini-stat:last-child {
+  border-right: none;
+}
+
+:deep(.mini-stat .ant-statistic-title) {
+  font-size: 11px;
+  color: #64748b;
+  font-weight: 500;
+  margin-bottom: 2px;
+}
+
+/* Selection tree */
+.selection-tree {
+  font-size: 13px;
+}
+
+:deep(.selection-tree .ant-tree-node-content-wrapper) {
+  color: #1e293b;
+}
+
+/* API endpoints */
+.endpoint-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.endpoint-path {
+  font-size: 11px;
+  background: #f1f5f9;
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: #4f46e5;
+}
+
+.endpoint-desc {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-top: 2px;
+}
+
+.endpoint-desc code {
+  background: #f1f5f9;
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: 11px;
+  color: #64748b;
+}
+
+/* Result box */
+.result-box {
+  margin-top: 16px;
+  padding: 12px 14px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+}
+
+.result-json {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #1e293b;
+  font-family: 'Courier New', monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* Transition */
+.result-fade-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.result-fade-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
+}
+</style>

--- a/apps/sample-vue-full/views/T4t.vue
+++ b/apps/sample-vue-full/views/T4t.vue
@@ -1,124 +1,165 @@
 <template>
-  <div class="main-container">
-    <div class="title-label">{{ table?.config?.displayName || props.tableName }}</div>
-    <div class="table-operations">
-      <a-button @click="filterApply" class="button-variation-1"
-        ><span class="button-variation-1-label">Reload</span></a-button
-      >
-      <a-button @click="filterOpen" class="button-variation-1"
-        ><span class="button-variation-1-label">Filter</span></a-button
-      >
-      <a-button v-if="table?.config?.create" @click="() => formOpen(null)" class="button-variation-2"
-        ><span class="button-variation-2-label">Create</span></a-button
-      >
-      <a-button v-if="table?.config?.delete" @click="deleteItems" class="button-variation-2"
-        ><span class="button-variation-2-label">Delete</span></a-button
-      >
-      <a-upload
-        style="margin-right: 8px;"
-        v-if="table?.config?.import"
-        name="csv-file"
-        :before-upload="importCsv"
-        :show-upload-list="false"
-        :max-count="1"
-        accept="text/csv"
-      >
-        <a-button class="button-variation-1"><span class="button-variation-1-label">Import</span></a-button>
-      </a-upload>
-      <a-button v-if="table?.config?.export" @click="exportCsv" class="button-variation-3"
-        ><span class="button-variation-3-label">Export</span></a-button
-      >
-      <a-button v-if="props?.filterKeys" @click="goBack" class="button-variation-1"
-        ><span class="button-variation-1-label">Back</span></a-button
-      >
-    </div>
-    <a-table
-      :columns="table.columns"
-      :data-source="table.data"
-      :pagination="table.pagination"
-      :scroll="{ x: table.scrollX, y: tableHeight }"
-      :loading="table.loading"
-      size="small"
-      @change="handleTableChange"
-      :row-key="'__key'"
-      :customRow="customRow"
-      :customHeaderRow="customHeaderRow"
-      :row-selection="rowSelection"
-      class="main-table"
-      @resizeColumn="handleResizeColumn"
-    >
-      <!-- <template #action="item">
-        <a-button @click="() => console.log(item)">{{ item.text }}</a-button>
-      </template> -->
-    </a-table>
+  <div class="t4t-view">
+    <a-card :bordered="false" class="t4t-card">
+      <template #title>
+        <div class="card-title-row">
+          <TableOutlined class="card-title-icon" />
+          <span>{{ table?.config?.displayName || props.tableName }}</span>
+          <a-badge
+            v-if="table.pagination.total"
+            :count="table.pagination.total"
+            :overflow-count="99999"
+            :number-style="{ background: '#4f46e5', fontSize: '11px' }"
+            style="margin-left: 8px"
+          />
+        </div>
+      </template>
+      <template #extra>
+        <a-space :size="6" wrap>
+          <a-button size="small" @click="filterApply">
+            <template #icon><ReloadOutlined /></template>
+            Reload
+          </a-button>
+          <a-button size="small" @click="filterOpen">
+            <template #icon><FilterOutlined /></template>
+            Filter
+            <a-badge
+              v-if="table.filters.length"
+              :count="table.filters.length"
+              :number-style="{ background: '#4f46e5', fontSize: '10px', marginLeft: '4px' }"
+            />
+          </a-button>
+          <a-button v-if="table?.config?.create" size="small" type="primary" @click="() => formOpen(null)">
+            <template #icon><PlusOutlined /></template>
+            Create
+          </a-button>
+          <a-button v-if="table?.config?.delete" size="small" danger @click="deleteItems">
+            <template #icon><DeleteOutlined /></template>
+            Delete
+          </a-button>
+          <a-upload
+            v-if="table?.config?.import"
+            name="csv-file"
+            :before-upload="importCsv"
+            :show-upload-list="false"
+            :max-count="1"
+            accept="text/csv"
+          >
+            <a-button size="small">
+              <template #icon><UploadOutlined /></template>
+              Import
+            </a-button>
+          </a-upload>
+          <a-button v-if="table?.config?.export" size="small" @click="exportCsv">
+            <template #icon><DownloadOutlined /></template>
+            Export
+          </a-button>
+          <a-button v-if="props?.filterKeys" size="small" @click="goBack">
+            <template #icon><ArrowLeftOutlined /></template>
+            Back
+          </a-button>
+        </a-space>
+      </template>
+
+      <a-table
+        :columns="table.columns"
+        :data-source="table.data"
+        :pagination="table.pagination"
+        :scroll="{ x: table.scrollX, y: tableHeight }"
+        :loading="table.loading"
+        size="small"
+        @change="handleTableChange"
+        :row-key="'__key'"
+        :customRow="customRow"
+        :customHeaderRow="customHeaderRow"
+        :row-selection="rowSelection"
+        class="t4t-table"
+        @resizeColumn="handleResizeColumn"
+      />
+    </a-card>
+
+    <!-- Filter Drawer -->
     <a-drawer
-      title="Filters (Max 10)"
-      :width="512"
+      title="Filters"
+      :width="520"
       :open="filterShow"
-      :body-style="{ paddingBottom: '80px' }"
-      @close="filterClose"
       placement="left"
+      @close="filterClose"
     >
+      <template #extra>
+        <a-tag v-if="table.filters.length" color="purple">{{ table.filters.length }} active</a-tag>
+      </template>
+      <template #footer>
+        <a-space>
+          <a-button @click="filterAdd" :disabled="table.filters.length > 9">
+            <template #icon><PlusOutlined /></template>
+            Add Filter
+          </a-button>
+          <a-button @click="filterClearAll" :disabled="table.filters.length === 0">Clear All</a-button>
+          <a-button type="primary" @click="filterApply">
+            <template #icon><CheckOutlined /></template>
+            Apply
+          </a-button>
+        </a-space>
+      </template>
+
       <a-form layout="vertical">
-        <a-form-item v-for="(filter, index) in table.filters" :key="index">
+        <a-empty
+          v-if="!table.filters.length"
+          description="No filters added yet"
+          :image="Empty.PRESENTED_IMAGE_SIMPLE"
+          style="margin: 40px 0"
+        />
+        <a-form-item v-for="(filter, index) in table.filters" :key="index" :label="`Filter ${index + 1}`">
           <a-input-group compact>
-            <a-select style="width: 125px" placeholder="Column" v-model:value="filter.col">
-              <a-select-option v-for="col in table.filterCols" :key="col.value" :value="col.value"
-                >{{ col.label }}</a-select-option
-              >
+            <a-select style="width: 130px" placeholder="Column" v-model:value="filter.col">
+              <a-select-option v-for="col in table.filterCols" :key="col.value" :value="col.value">
+                {{ col.label }}
+              </a-select-option>
             </a-select>
-            <a-select style="width: 75px" placeholder="Operation" v-model:value="filter.op">
+            <a-select style="width: 80px" placeholder="Op" v-model:value="filter.op">
               <a-select-option v-for="op in table.filterOps" :key="op" :value="op">{{ op }}</a-select-option>
             </a-select>
             <a-input
-              style="width: 125px"
+              style="width: 140px"
               placeholder="Value"
               v-model:value="filter.val"
               :type="table?.config?.cols[filter?.col]?.ui?.attrs?.type || 'text'"
             />
-            <a-select style="width: 75px" placeholder="And Or" v-model:value="filter.andOr">
-              <a-select-option v-for="andOr in table.filterAndOr" :key="andOr" :value="andOr"
-                >{{ andOr }}</a-select-option
-              >
+            <a-select style="width: 74px" placeholder="And/Or" v-model:value="filter.andOr">
+              <a-select-option v-for="andOr in table.filterAndOr" :key="andOr" :value="andOr">{{ andOr }}</a-select-option>
             </a-select>
-            <a-button type="primary" @click="() => filterDelete(index)">
+            <a-button danger @click="() => filterDelete(index)">
               <template #icon><CloseOutlined /></template>
             </a-button>
           </a-input-group>
         </a-form-item>
       </a-form>
-      <a-button
-        :disabled="table.filters.length > 9"
-        style="margin-bottom: 8px"
-        @click="filterAdd"
-        class="button-variation-1"
-        ><span class="button-variation-1-label">Add Filter</span></a-button
-      >
-      <a-button
-        :disabled="table.filters.length === 0"
-        style="margin-bottom: 8px; margin-left: 8px"
-        @click="filterClearAll"
-        class="button-variation-1"
-        ><span class="button-variation-1-label">Clear All</span></a-button
-      >
-      <div class="t4t-drawer">
-        <a-button type="primary" @click="filterApply" style="margin-left: 25px" class="button-variation-2"
-          ><span class="button-variation-2-label">Apply</span></a-button
-        >
-      </div>
     </a-drawer>
+
+    <!-- Add / Edit Drawer -->
     <a-drawer
-      :title="formMode"
-      :width="480"
+      :title="formMode === 'add' ? 'Create Record' : 'Edit Record'"
+      :width="500"
       :open="!!formMode"
-      :body-style="{ paddingBottom: '80px' }"
       @close="formClose"
     >
+      <template #extra>
+        <a-tag :color="formMode === 'add' ? 'green' : 'blue'">{{ formMode }}</a-tag>
+      </template>
+      <template #footer>
+        <a-space>
+          <a-button @click="formClose">Cancel</a-button>
+          <a-button v-if="table?.config?.update" type="primary" @click="formSubmit">
+            <template #icon><SaveOutlined /></template>
+            Save Changes
+          </a-button>
+        </a-space>
+      </template>
+
       <a-form layout="vertical" :model="table.formData" :rules="table.formRules">
         <template v-for="(colObj, col, index) in table.formCols" :key="col">
           <a-form-item :label="colObj.label" :rules="colRequired(col)" v-if="colShow(colObj)">
-            <!-- <a-input v-model:value="table.formData[col]" v-bind="table.formColAttrs[col]"/> -->
-            <!-- <div>{{ index }} {{ table.formData[col] }}</div><br/> -->
             <a-textarea
               v-if="colUiType(colObj, 'textarea')"
               v-model:value="table.formData[col]"
@@ -132,11 +173,14 @@
             <div v-else-if="colUiType(colObj, 'files')">
               <a-upload
                 :file-list="table.formFiles[col]"
-                :before-upload="(file) => beforeUpload(file,col)"
-                @remove="(file) => handleRemove(file,col)"
+                :before-upload="(file) => beforeUpload(file, col)"
+                @remove="(file) => handleRemove(file, col)"
                 v-bind="table.formColAttrs[col]"
               >
-                <a-button> Select File </a-button>
+                <a-button>
+                  <template #icon><UploadOutlined /></template>
+                  Select File
+                </a-button>
               </a-upload>
               <div>{{ table.formData[col] }}</div>
               <a-image v-if="table.formData[col]" :alt="table.formData[col]" :width="200" :src="openImg(col)" />
@@ -146,35 +190,38 @@
               v-model:value="table.formData[col]"
               v-bind="table.formColAttrs[col]"
               :options="table.formColAc[col].options"
-              style="width: 200px"
-              placeholder="input here"
-              @select="(value, option)=>onAcSelect(col, value, option)"
-              @search="(value)=>debouncedAcSearch(value, col, table.formData)"
+              style="width: 100%"
+              placeholder="Type to search..."
+              @select="(value, option) => onAcSelect(col, value, option)"
+              @search="(value) => debouncedAcSearch(value, col, table.formData)"
             />
             <a-input v-else v-model:value="table.formData[col]" v-bind="table.formColAttrs[col]" />
-            <!-- <div v-else>[{{ index }}] {{ table.formData[col] }}</div><br/> -->
           </a-form-item>
         </template>
-        <!-- TODOOOO single autocomplete, multi autocomplete, multi select -->
       </a-form>
-      <div class="t4t-drawer">
-        <a-button v-if="table?.config?.update" style="margin-left: 25px" @click="formSubmit" class="button-variation-2"
-          ><span class="button-variation-2-label">Save Changes</span></a-button
-        >
-        <a-button style="margin-left: 10px" @click="formClose" class="button-variation-1"
-          ><span class="button-variation-1-label">Cancel</span></a-button
-        >
-      </div>
     </a-drawer>
   </div>
 </template>
+
 <script>
-import { CloseOutlined } from '@ant-design/icons-vue';
+import {
+  ArrowLeftOutlined,
+  CheckOutlined,
+  CloseOutlined,
+  DeleteOutlined,
+  DownloadOutlined,
+  FilterOutlined,
+  PlusOutlined,
+  ReloadOutlined,
+  SaveOutlined,
+  TableOutlined,
+  UploadOutlined,
+} from '@ant-design/icons-vue';
 import { getLocaleDateTimeTzISO, getTzOffsetISO, getYmdhmsUtc } from '@common/iso/datetime';
 import { http } from '@common/vue/plugins/fetch.js';
-import * as t4tFe from '@common/web/t4t-fe'; // Reference - https://github.com/es-labs/jslib/blob/main/libs/esm/t4t-fe.js
+import * as t4tFe from '@common/web/t4t-fe';
 import { debounce, downloadData } from '@common/web/util';
-import { notification } from 'ant-design-vue';
+import { Empty, notification } from 'ant-design-vue';
 import { onBeforeUnmount, onMounted, reactive, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useMainStore } from '../store.js';
@@ -186,23 +233,30 @@ export default {
   name: 'T4t',
   props: ['tableName', 'filterKeys', 'filterVals'],
   components: {
+    ArrowLeftOutlined,
+    CheckOutlined,
     CloseOutlined,
+    DeleteOutlined,
+    DownloadOutlined,
+    FilterOutlined,
+    PlusOutlined,
+    ReloadOutlined,
+    SaveOutlined,
+    TableOutlined,
+    UploadOutlined,
   },
   setup(props, context) {
-    console.log('t4t - v0.0.2');
     const store = useMainStore();
     const router = useRouter();
-    // const loading = store.loading
 
-    // table information
     const table = reactive({
       scroll: { x: 1800, y: 240 },
-      pagination: { pageSize: DEFAULT_PAGE_SIZE, total: 0, current: 1 }, // start at page 1, 8 records per page
-      sorter: null, // single sort only
+      pagination: { pageSize: DEFAULT_PAGE_SIZE, total: 0, current: 1 },
+      sorter: null,
 
       filters: [],
       filterCols: [],
-      filterOps: ['like', '=', '!=', '>=', '>', '<', '<='], // isNull, isEmpty
+      filterOps: ['like', '=', '!=', '>=', '>', '<', '<='],
       filterAndOr: ['and', 'or'],
 
       keyCols: [],
@@ -214,16 +268,15 @@ export default {
       formKey: null,
       formData: {},
       formFiles: {},
-      formRules: {}, // To Remove
+      formRules: {},
       formCols: {},
-      formColAttrs: {}, // attributes for your inputs
-      formColAc: {}, // autocomplete properties
+      formColAttrs: {},
+      formColAc: {},
       scrollX: 1800,
     });
 
-    const filterShow = ref(false); // Filter drawer
+    const filterShow = ref(false);
 
-    // Deletion
     const deleteItems = async () => {
       if (!confirm('Delete Items?')) return;
       const numSelected = rowSelection.selectedRowKeys.length;
@@ -240,14 +293,12 @@ export default {
           await fetchData();
           notification.open({ message, duration, description: 'Success' });
         } catch (e) {
-          console.log('t4t delete error', e.toString());
           notification.open({ message, duration, description: 'Error' });
         }
         store.loading = false;
       }
     };
 
-    // File Handling
     const handleRemove = (file, col) => {
       const index = table.formFiles[col].indexOf(file);
       const newFileList = table.formFiles[col].slice();
@@ -255,18 +306,16 @@ export default {
       table.formFiles[col] = newFileList;
     };
     const beforeUpload = (file, col) => {
-      console.log('beforeUpload');
       const maxFiles = table.config.cols[col]?.ui?.attrs?.maxCount || 0;
       if (table.formFiles[col].length === maxFiles) {
-        alert(`Maximum ${maxFiles} Files Exceeded. Remove a file before adding`); // have a problem, can keep popping up...
+        alert(`Maximum ${maxFiles} Files Exceeded. Remove a file before adding`);
       } else {
         table.formFiles[col] = [...(table.formFiles[col] || []), file];
       }
       return false;
     };
 
-    // Add / Edit Form
-    const formMode = ref(false); // false, add or edit
+    const formMode = ref(false);
     const formOpen = async item => {
       table.formData = {};
       table.formFiles = {};
@@ -285,31 +334,19 @@ export default {
         for (const colName in table.config.cols) {
           const col = table.config.cols[colName];
           if (
-            !(
-              (
-                col[mode] && // mode is found
-                col.type !== 'link' && // column is not link type
-                !(col.auto && mode === 'add') && // column is not auto or column is auto but mode is not add
-                !(col.hide && col.hide !== 'blank')
-              ) // column is not hide or column is hide but blank
-            )
+            !(col[mode] && col.type !== 'link' && !(col.auto && mode === 'add') && !(col.hide && col.hide !== 'blank'))
           )
             continue;
 
           table.formCols[colName] = col;
-          table.formData[colName] = mode === 'add' ? table.config.cols[colName].default || '' : rv[colName]; // get the data // TODO May need formatting?
+          table.formData[colName] = mode === 'add' ? table.config.cols[colName].default || '' : rv[colName];
           table.formColAttrs[colName] = {
             ...col.ui?.attrs,
             disabled:
               (mode === 'add' && col.add === 'readonly') || (mode === 'edit' && (col.edit === 'readonly' || col.auto)),
             required: col.required,
           };
-          // if (col?.ui?.tag === 'select') {
-          //   console.log('yyyy', table.formColAttrs[colName], table.formData[colName])
-          // }
-          // Do For Form - table.formData[colName] = mapRecordCol(table.formData, colName)
-          if (col?.ui?.tag === 'files')
-            table.formFiles[colName] = []; // add file
+          if (col?.ui?.tag === 'files') table.formFiles[colName] = [];
           else if (col?.ui?.tag === 'autocomplete') {
             table.formColAc[colName] = { options: [] };
             table.formData[colName] = {
@@ -321,45 +358,37 @@ export default {
             table.formData[colName] = getLocaleDateTimeTzISO(table.formData[colName]).substring(0, 16);
           }
         }
-        // console.log('table.formData', table.formData)
-        // console.log('table.formCols', table.formCols)
-        console.log('table.formColAttrs', table.formColAttrs);
       } catch (e) {
-        console.log('formOpen', e.toString());
+        notification.open({ message: 'Open Form', duration: 3, description: e.toString() });
       }
       if (Object.keys(table.formCols).length !== 0) formMode.value = mode;
     };
+
     const formSubmit = async () => {
       const formData = new FormData();
       const jsonData = {};
-      // input processing...
       for (const col in table.formData) {
         jsonData[col] = table.formData[col];
-
         if (table.formFiles[col]) {
-          // handle files
           if (table.formFiles[col].length) {
             jsonData[col] = '';
             for (const file of table.formFiles[col]) {
               jsonData[col] = jsonData[col] ? `${jsonData[col]},${file.name}` : file.name;
               formData.append(col, file, file.name);
             }
-          } else {
-            // TODO clearing file
-            // jsonData[col] = ''
           }
         }
         if (table.config.cols[col]?.ui?.tag === 'autocomplete') {
           jsonData[col] = table.formData[col]?.key;
         } else if (table.config.cols[col]?.ui?.attrs?.type === 'datetime-local') {
-          jsonData[col] = new Date(table.formData[col]).toISOString(); // 2024-12-24 08:00 - 16 chars... convert to ISO
+          jsonData[col] = new Date(table.formData[col]).toISOString();
         }
       }
       formData.append('json', JSON.stringify(jsonData));
       if (store.loading === false) {
         store.loading = true;
         const message = formMode.value === 'add' ? 'Add' : 'Update';
-        const duration = 3; // seconds
+        const duration = 3;
         try {
           if (formMode.value === 'add') {
             await t4tFe.create(formData);
@@ -369,21 +398,20 @@ export default {
           await fetchData();
           notification.open({ message, duration, description: 'Success' });
         } catch (e) {
-          console.log('t4t submit error', e.toString());
           notification.open({ message, duration, description: 'Error' });
         }
         store.loading = false;
       }
       formMode.value = false;
     };
+
     const rowSelection = reactive({
       selectedRowKeys: [],
       onChange: selectedRowKeys => {
-        // Check here to configure the default column
-        console.log('selectedRowKeys changed: ', selectedRowKeys);
         rowSelection.selectedRowKeys = selectedRowKeys;
       },
     });
+
     const mapRecordCol = (record, _col) => {
       const colObj = table.config.cols[_col];
       if (colObj?.ui?.tag === 'autocomplete' && colObj.options) {
@@ -391,39 +419,36 @@ export default {
         if (display && record[_col][display]) {
           record[_col] = record[_col][display];
         } else if (typeof record[_col] !== 'string') {
-          // TODO handle display === both
           record[_col] = JSON.stringify(record[_col]);
         }
-      } else if (colObj?.ui?.tag === 'select') {
-        // TODO display label
       }
       return record[_col];
     };
+
     const mapRecord = record => {
       for (const _col in table.config.cols) {
         const tableCol = table.config.cols[_col];
         if (tableCol.type === 'link') {
-          // no mapping needed for now
+          // no mapping needed
         } else if (record[_col]) {
           record[_col] = mapRecordCol(record, _col);
         }
       }
       return record;
     };
-    // const hasSelected = computed(() => state.selectedRowKeys.length > 0);
+
     const fetchData = async () => {
       if (table.loading) return;
       table.loading = true;
       try {
-        const filters = JSON.parse(JSON.stringify(table.filters)); // [ ...table.filters ]
+        const filters = JSON.parse(JSON.stringify(table.filters));
         for (const [index, filter] of filters.entries()) {
-          // convert filter data here...
           const attrsType = table.config.cols[filter?.col]?.ui?.attrs?.type;
           if (attrsType === 'datetime-local') {
-            filters[index].val += `:00${getTzOffsetISO()}`; // convert to UTC
+            filters[index].val += `:00${getTzOffsetISO()}`;
           }
         }
-        const { filterKeys, filterVals } = props; // child table filter...
+        const { filterKeys, filterVals } = props;
         if (filterKeys?.length && filterVals?.length) {
           const filterKeysA = filterKeys.split(',');
           const filterValsA = filterVals.split(',');
@@ -432,8 +457,7 @@ export default {
           }
         }
         const { results, total } = await t4tFe.find(filters, null, table.pagination.current, table.pagination.pageSize);
-        // console.log('columns', table.columns, 'results', results, total)
-        table.data = results.map(result => mapRecord(result)); // format the results...
+        table.data = results.map(result => mapRecord(result));
         table.pagination.total = total;
       } catch (e) {
         alert(`Error find${e.toString()}`);
@@ -441,24 +465,19 @@ export default {
       table.loading = false;
     };
 
-    // const getRowKey = (record) => table.keyCols.map(keyCol => record[keyCol]).join('|')
-
     onMounted(async () => {
       t4tFe.setFetch(http);
       t4tFe.setTableName(props.tableName);
-      // console.log(props, context)
 
       if (store.loading === false) {
         store.loading = true;
         try {
           table.config = await t4tFe.getConfig();
         } catch (e) {
-          console.log('table config error', e.toString());
           alert('Error Loading Table Configuration');
         }
         if (table.config) {
           try {
-            console.log('TABLE CONFIG', table.config);
             for (const key in table.config.cols) {
               const val = table.config.cols[key];
               if (val.multiKey || val.auto === 'pk') table.keyCols.push(key);
@@ -467,25 +486,20 @@ export default {
                 dataIndex: key,
                 filter: val.filter,
                 sorter: val.sort,
-                __type: val.type || 'text', // aka type
+                __type: val.type || 'text',
                 ui: val.ui,
                 customCell: (record, rowIndex, column) => {
                   const key = column.dataIndex;
                   const rv = {
                     onClick: event => {
-                      // console.log('onClick', rowIndex, record, column, event)
                       if (column?.__type === 'link') {
                         const col = table.config.cols[key];
-                        console.log(col);
                         let fvals = '';
                         const keys_a = col.link.keys.split(',');
                         for (const linkKey of keys_a) {
-                          console.log('linkKey', linkKey, record);
                           if (fvals) fvals += `,${record[linkKey]}`;
                           else fvals = record[linkKey];
                         }
-                        // console.log(col.link.ctable, col.link.ckeys, fvals)
-                        // TOCHECK replace with t4tfe parentFilter?
                         router.push({
                           path: '/t4t-link',
                           name: 'T4t-Link',
@@ -497,10 +511,9 @@ export default {
                       }
                     },
                   };
-                  // if (column?.__type === 'link') rv.innerHTML = record[key] + ' - ' + table.config.cols[key].link?.text // || 'Click To View'
                   return rv;
                 },
-                resizable: true, // these 2 for resizing
+                resizable: true,
                 width: 100,
                 ellipsis: true,
                 customRender(e) {
@@ -520,7 +533,6 @@ export default {
               .map(col => ({ value: col.dataIndex, label: col.title }));
             await fetchData();
           } catch (e) {
-            console.log('table load error', e.toString());
             alert('Error Loading Table Data');
           }
         }
@@ -529,7 +541,6 @@ export default {
     });
 
     const handleTableChange = async (pagination, filters, sorter) => {
-      // console.log('handleTableChange', pagination, filters, sorter) // use own filters
       table.pagination = { ...pagination };
       table.sorter = { ...sorter };
       if (store.loading === false) {
@@ -539,15 +550,13 @@ export default {
       }
     };
 
-    // onClick, onDblclick, onMouseenter, onMouseleave, onContextmenu: (event) => {}
     const customRow = (record, index) => ({});
     const customHeaderRow = column => ({});
 
-    // CSV
     const importCsv = async file => {
+      const message = 'Import CSV';
+      const duration = 3;
       try {
-        const message = 'Import CSV';
-        const duration = 3;
         const { data } = await t4tFe.upload(file);
         if (data.errorCount > 0) {
           notification.open({ message, duration, description: 'Errors - downloading...' });
@@ -557,14 +566,13 @@ export default {
         }
       } catch (e) {
         notification.open({ message, duration, description: 'Failed' });
-        console.log(e);
       }
       return false;
     };
+
     const exportCsv = async () => {
-      // FIX REPEATING CODE START
       const filters = [...table.filters];
-      const { filterKeys, filterVals } = props; // child table filter...
+      const { filterKeys, filterVals } = props;
       if (filterKeys?.length && filterVals?.length) {
         const filterKeysA = filterKeys.split(',');
         const filterValsA = filterVals.split(',');
@@ -572,29 +580,22 @@ export default {
           filters.push({ andOr: 'and', col: filterKeysA[index], op: '=', val: filterValsA[index] });
         }
       }
-      // FIX REPEATING CODE END
-
       const sorter = null;
       const message = 'Export CSV';
       const duration = 3;
       try {
         const data = await t4tFe.download(filters, sorter);
-        downloadData(data.csv, `${(new Date()).toISOString()}-${props.tableName}.csv`);
+        downloadData(data.csv, `${new Date().toISOString()}-${props.tableName}.csv`);
         notification.open({ message, duration, description: 'Success' });
       } catch (e) {
         notification.open({ message, duration, description: 'Failed' });
-        console.log(e);
       }
     };
 
-    // t4tFe.autocomplete
-
-    //responsive table height
     const tableHeight = ref(0);
-    const OFFSET_HEIGHT = 306; // IMPORTANT! - Adjust based on your layout (headers, footers, etc.)
+    const OFFSET_HEIGHT = 306;
     const handleResize = () => {
-      const windowHeight = window.innerHeight;
-      tableHeight.value = windowHeight - OFFSET_HEIGHT;
+      tableHeight.value = window.innerHeight - OFFSET_HEIGHT;
     };
     onMounted(() => {
       handleResize();
@@ -605,6 +606,7 @@ export default {
     });
 
     return {
+      Empty,
       props,
       goBack: () => router.go(-1),
       colShow: val => (formMode.value === 'add' && val.add) || (formMode.value === 'edit' && val.edit),
@@ -613,10 +615,8 @@ export default {
         { required: !!table.formColAttrs[val]?.required, message: `${table.formCols[val]?.label} is required` },
       ],
       openImg: col => {
-        // TODO handle multiple files
         const file = table.formData[col];
         const path = table.config.cols[col]?.ui?.url;
-        // console.log(path, file)
         return `${path + file}`;
       },
       table,
@@ -624,10 +624,8 @@ export default {
       customRow,
       customHeaderRow,
 
-      // filters
       filterShow,
       filterApply: async () => {
-        // also used for reload
         if (store.loading === false) {
           store.loading = true;
           await fetchData();
@@ -640,42 +638,32 @@ export default {
       filterClearAll: () => (table.filters = []),
       filterDelete: index => table.filters.splice(index, 1),
 
-      // csv
       importCsv,
       exportCsv,
 
-      // forms
       formMode,
       formOpen,
       formSubmit,
       formClose: () => (formMode.value = false),
 
-      // others
       rowSelection,
       deleteItems,
 
-      //responsive table height
       tableHeight,
       handleResizeColumn: (w, col) => (col.width = w),
 
-      // files
       handleRemove,
       beforeUpload,
 
-      // autocomplete - search
       debouncedAcSearch: debounce(async (text, col, record) => {
-        // console.log('debounced2', text, col, record) // do the search here...
         const res = await t4tFe.autocomplete(text, col, record);
         table.formColAc[col].options = res.map(item => ({
           key: item.key,
           label: item.text,
           value: item.text,
         }));
-      }, 500), // when tab key pressed or focus lost,
-      // autocomplete - select
+      }, 500),
       onAcSelect: (col, text, option) => {
-        // value, label
-        console.log('select', col, text, option); // actually the value..., displayed is also the value...
         table.formData[col] = option;
       },
     };
@@ -684,5 +672,55 @@ export default {
 </script>
 
 <style scoped>
-@import 'T4t.css';
+.t4t-view {
+  font-family: 'DM Sans', sans-serif;
+}
+
+.t4t-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+:deep(.t4t-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 52px;
+}
+
+:deep(.t4t-card .ant-card-body) {
+  padding: 16px 20px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 16px;
+}
+
+:deep(.t4t-table .ant-table-thead > tr > th) {
+  background: #f8fafc;
+  font-size: 12px;
+  font-weight: 600;
+  color: #64748b;
+  padding: 8px 12px;
+}
+
+:deep(.t4t-table .ant-table-tbody > tr > td) {
+  font-size: 13px;
+  color: #1e293b;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+:deep(.t4t-table .ant-table-tbody > tr:hover > td) {
+  background: #f1f5f9;
+}
 </style>

--- a/apps/sample-vue-full/views/T4t.vue
+++ b/apps/sample-vue-full/views/T4t.vue
@@ -441,7 +441,7 @@ export default {
       if (table.loading) return;
       table.loading = true;
       try {
-        const filters = JSON.parse(JSON.stringify(table.filters));
+        const filters = structuredClone(table.filters);
         for (const [index, filter] of filters.entries()) {
           const attrsType = table.config.cols[filter?.col]?.ui?.attrs?.type;
           if (attrsType === 'datetime-local') {

--- a/apps/sample-vue-full/views/Visuals/DemoChart1.vue
+++ b/apps/sample-vue-full/views/Visuals/DemoChart1.vue
@@ -1,48 +1,279 @@
 <template>
-  <canvas id="id-chart"></canvas>
+  <div class="demo-chart1">
+    <a-row :gutter="[16, 16]">
+
+      <!-- Summary stats -->
+      <a-col v-for="stat in stats" :key="stat.title" :xs="12" :sm="6">
+        <a-card :bordered="false" class="stat-card">
+          <a-statistic
+            :title="stat.title"
+            :value="stat.value"
+            :precision="stat.precision"
+            :prefix="stat.prefix"
+            :value-style="{ color: stat.color, fontWeight: 700 }"
+          >
+            <template #suffix>
+              <span v-if="stat.suffix" :style="{ color: stat.color }">{{ stat.suffix }}</span>
+              <component
+                :is="stat.trend === 'up' ? icons.ArrowUpOutlined : icons.ArrowDownOutlined"
+                :style="{ color: stat.trend === 'up' ? '#16a34a' : '#dc2626', fontSize: '14px', marginLeft: '4px' }"
+              />
+            </template>
+          </a-statistic>
+          <div class="stat-sub">{{ stat.sub }}</div>
+        </a-card>
+      </a-col>
+
+      <!-- Bar chart — Monthly Revenue -->
+      <a-col :xs="24" :lg="16">
+        <ChartCard
+          title="Monthly Revenue"
+          :title-icon="icons.BarChartOutlined"
+          chart-type="bar"
+          :labels="barLabels"
+          :datasets="barDatasets"
+          :height="260"
+          :options="barOptions"
+        >
+          <template #extra>
+            <a-radio-group v-model:value="barPeriod" size="small" button-style="solid" @change="onBarPeriodChange">
+              <a-radio-button value="q1">Q1</a-radio-button>
+              <a-radio-button value="q2">Q2</a-radio-button>
+              <a-radio-button value="q3">Q3</a-radio-button>
+              <a-radio-button value="q4">Q4</a-radio-button>
+            </a-radio-group>
+          </template>
+        </ChartCard>
+      </a-col>
+
+      <!-- Doughnut chart — Category Split -->
+      <a-col :xs="24" :lg="8">
+        <ChartCard
+          title="Category Split"
+          :title-icon="icons.PieChartOutlined"
+          chart-type="doughnut"
+          :labels="donutLabels"
+          :datasets="donutDatasets"
+          :height="260"
+          :options="donutOptions"
+        />
+      </a-col>
+
+      <!-- Line chart — User Growth -->
+      <a-col :span="24">
+        <ChartCard
+          title="User Growth Trend"
+          :title-icon="icons.LineChartOutlined"
+          chart-type="line"
+          :labels="lineLabels"
+          :datasets="lineDatasets"
+          :height="220"
+          :options="lineOptions"
+        >
+          <template #extra>
+            <a-select v-model:value="lineYear" size="small" style="width:90px" @change="onLineYearChange">
+              <a-select-option value="2024">2024</a-select-option>
+              <a-select-option value="2025">2025</a-select-option>
+            </a-select>
+          </template>
+        </ChartCard>
+      </a-col>
+
+    </a-row>
+  </div>
 </template>
 
 <script setup>
-import Chart from 'chart.js/auto';
-import { onMounted, reactive } from 'vue';
+import {
+  ArrowDownOutlined,
+  ArrowUpOutlined,
+  BarChartOutlined,
+  LineChartOutlined,
+  PieChartOutlined,
+} from '@ant-design/icons-vue';
+import { markRaw, ref } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: component used in Vue template
+import ChartCard from '../../components/ChartCard.vue';
 
-let chart = null;
+const icons = markRaw({ ArrowDownOutlined, ArrowUpOutlined, BarChartOutlined, LineChartOutlined, PieChartOutlined });
 
-const data = reactive({
-  labels: ['January', 'February', 'March'],
-  data0: [40, 20, 12],
-});
+const stats = [
+  {
+    title: 'Total Revenue',
+    value: 128400,
+    prefix: '$',
+    color: '#4f46e5',
+    trend: 'up',
+    sub: '+12.5% from last quarter',
+  },
+  { title: 'Active Users', value: 3842, color: '#0891b2', trend: 'up', sub: '+8.3% from last month' },
+  {
+    title: 'Conversion Rate',
+    value: 4.7,
+    precision: 1,
+    suffix: '%',
+    color: '#d97706',
+    trend: 'down',
+    sub: '-0.4% from last month',
+  },
+  {
+    title: 'Avg. Order Value',
+    value: 33.4,
+    precision: 1,
+    prefix: '$',
+    color: '#16a34a',
+    trend: 'up',
+    sub: '+2.1% from last week',
+  },
+];
 
-// const options = reactive({ responsive: true })
+// --- Bar chart ---
+const barPeriod = ref('q1');
 
-onMounted(async () => {
-  const chartElId = document.getElementById('id-chart');
-  if (!chart && chartElId) {
-    chart = new Chart(chartElId, {
-      type: 'bar', // 'line',
-      data: {
-        labels: data.labels,
-        datasets: [
-          {
-            label: 'Reading',
-            barThickness: 1,
-            maxBarThickness: 1,
-            data: data.data0,
-          },
-        ],
-      },
-    });
-  } else {
-    // update chart table and data
-    chart.data.labels = data.labels;
-    chart.data.datasets[0].data = data.data0;
-    chart.update();
-  }
-});
+const barData = {
+  q1: { labels: ['Jan', 'Feb', 'Mar'], revenue: [18200, 22400, 19800], orders: [340, 410, 370] },
+  q2: { labels: ['Apr', 'May', 'Jun'], revenue: [24100, 27600, 23900], orders: [420, 490, 430] },
+  q3: { labels: ['Jul', 'Aug', 'Sep'], revenue: [21500, 25800, 28300], orders: [390, 460, 510] },
+  q4: { labels: ['Oct', 'Nov', 'Dec'], revenue: [29400, 34200, 38800], orders: [530, 620, 710] },
+};
 
-// watch(
-//   () => chartStore.c2data, //  better not to watch deep...
-//   (currentValue, oldValue) => if (chart2) chart2.render(),
-//   { deep: true }
-// )
+const barLabels = ref(barData.q1.labels);
+const barDatasets = ref([
+  {
+    label: 'Revenue ($)',
+    data: barData.q1.revenue,
+    backgroundColor: 'rgba(79,70,229,0.75)',
+    borderRadius: 6,
+    yAxisID: 'y',
+  },
+  {
+    label: 'Orders',
+    data: barData.q1.orders,
+    backgroundColor: 'rgba(8,145,178,0.65)',
+    borderRadius: 6,
+    yAxisID: 'y1',
+  },
+]);
+
+const barOptions = {
+  scales: {
+    y: { position: 'left', ticks: { color: '#64748b' }, grid: { color: '#f1f5f9' } },
+    y1: { position: 'right', ticks: { color: '#64748b' }, grid: { drawOnChartArea: false } },
+    x: { ticks: { color: '#64748b' }, grid: { color: '#f1f5f9' } },
+  },
+};
+
+const onBarPeriodChange = () => {
+  const d = barData[barPeriod.value];
+  barLabels.value = d.labels;
+  barDatasets.value[0].data = d.revenue;
+  barDatasets.value[1].data = d.orders;
+};
+
+// --- Doughnut chart ---
+const donutLabels = ['Electronics', 'Clothing', 'Home & Garden', 'Sports', 'Other'];
+const donutDatasets = [
+  {
+    data: [35, 25, 18, 14, 8],
+    backgroundColor: ['#4f46e5', '#0891b2', '#16a34a', '#d97706', '#94a3b8'],
+    borderWidth: 2,
+    borderColor: '#ffffff',
+    hoverOffset: 8,
+  },
+];
+const donutOptions = {
+  plugins: { legend: { position: 'right' } },
+  cutout: '62%',
+};
+
+// --- Line chart ---
+const lineYear = ref('2025');
+
+const lineData = {
+  2024: {
+    new: [210, 240, 190, 310, 280, 350, 320, 410, 390, 440, 460, 500],
+    returning: [180, 200, 175, 260, 240, 290, 270, 340, 320, 370, 390, 420],
+  },
+  2025: {
+    new: [520, 570, 490, 640, 710, 680, 750, 820, 790, 870, 910, 980],
+    returning: [430, 480, 410, 540, 600, 570, 640, 700, 670, 740, 780, 840],
+  },
+};
+
+const lineLabels = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const lineDatasets = ref([
+  {
+    label: 'New Users',
+    data: lineData[2025].new,
+    borderColor: '#4f46e5',
+    backgroundColor: 'rgba(79,70,229,0.1)',
+    fill: true,
+    tension: 0.4,
+    pointRadius: 3,
+    pointHoverRadius: 6,
+  },
+  {
+    label: 'Returning Users',
+    data: lineData[2025].returning,
+    borderColor: '#0891b2',
+    backgroundColor: 'rgba(8,145,178,0.08)',
+    fill: true,
+    tension: 0.4,
+    pointRadius: 3,
+    pointHoverRadius: 6,
+  },
+]);
+
+const lineOptions = {
+  scales: {
+    y: { ticks: { color: '#64748b' }, grid: { color: '#f1f5f9' } },
+    x: { ticks: { color: '#64748b' }, grid: { color: '#f1f5f9' } },
+  },
+};
+
+const onLineYearChange = () => {
+  const d = lineData[lineYear.value];
+  lineDatasets.value[0].data = d.new;
+  lineDatasets.value[1].data = d.returning;
+};
 </script>
+
+<style scoped>
+.demo-chart1 {
+  font-family: 'DM Sans', sans-serif;
+}
+
+.stat-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  height: 100%;
+}
+
+:deep(.stat-card .ant-card-body) {
+  padding: 16px 20px;
+}
+
+:deep(.stat-card .ant-statistic-title) {
+  font-size: 12px;
+  color: #64748b;
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+
+:deep(.stat-card .ant-statistic-content) {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+:deep(.stat-card .ant-statistic-content-value) {
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.stat-sub {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-top: 6px;
+}
+</style>

--- a/apps/sample-vue-full/views/Visuals/DemoLeaflet.vue
+++ b/apps/sample-vue-full/views/Visuals/DemoLeaflet.vue
@@ -1,43 +1,355 @@
 <template>
-  <div>
-    <h1>Leaflet Map - TODO</h1>
-    <div id="map" class="map"></div>
+  <div class="demo-leaflet">
+    <a-row :gutter="[16, 16]">
+
+      <!-- Map card -->
+      <a-col :xs="24" :lg="16">
+        <a-card :bordered="false" class="map-card">
+          <template #title>
+            <div class="card-title-row">
+              <EnvironmentOutlined class="card-title-icon" />
+              <span>Interactive Map</span>
+              <a-tag :color="tileLayer === 'dark' ? 'default' : 'blue'" style="margin-left:auto;font-size:11px">
+                {{ tileLabels[tileLayer] }}
+              </a-tag>
+            </div>
+          </template>
+          <template #extra>
+            <a-radio-group v-model:value="tileLayer" size="small" button-style="solid">
+              <a-radio-button value="osm">Street</a-radio-button>
+              <a-radio-button value="topo">Topo</a-radio-button>
+              <a-radio-button value="dark">Dark</a-radio-button>
+            </a-radio-group>
+          </template>
+
+          <div class="map-wrapper">
+            <LeafletMap
+              ref="mapRef"
+              :center="mapCenter"
+              :zoom="mapZoom"
+              :markers="markers"
+              :tile-layer="tileLayer"
+              @marker-click="onMarkerClick"
+            />
+          </div>
+        </a-card>
+      </a-col>
+
+      <!-- Sidebar -->
+      <a-col :xs="24" :lg="8">
+        <a-row :gutter="[0, 12]">
+
+          <!-- Stats row -->
+          <a-col :span="12">
+            <a-card :bordered="false" class="mini-stat-card">
+              <a-statistic
+                title="Total Locations"
+                :value="markers.length"
+                :value-style="{ color: '#4f46e5', fontSize: '22px', fontWeight: 700 }"
+              />
+            </a-card>
+          </a-col>
+          <a-col :span="12" style="padding-left:6px">
+            <a-card :bordered="false" class="mini-stat-card">
+              <a-statistic
+                title="Active Markers"
+                :value="markers.filter(m => m.active).length"
+                :value-style="{ color: '#16a34a', fontSize: '22px', fontWeight: 700 }"
+              />
+            </a-card>
+          </a-col>
+
+          <!-- Location list -->
+          <a-col :span="24">
+            <a-card :bordered="false" class="location-card">
+              <template #title>
+                <div class="card-title-row">
+                  <UnorderedListOutlined class="card-title-icon" />
+                  <span>Locations</span>
+                  <a-badge :count="markers.length" :number-style="{ background: '#4f46e5' }" style="margin-left:auto" />
+                </div>
+              </template>
+              <template #extra>
+                <a-button type="text" size="small" @click="showAddModal = true">
+                  <template #icon><PlusOutlined /></template>
+                  Add
+                </a-button>
+              </template>
+
+              <a-list :data-source="markers" size="small" :split="true">
+                <template #renderItem="{ item }">
+                  <a-list-item
+                    class="location-item"
+                    :class="{ 'location-item--active': selectedId === item.id }"
+                    @click="flyToMarker(item)"
+                  >
+                    <a-list-item-meta>
+                      <template #avatar>
+                        <a-avatar
+                          :style="{ background: item.active ? '#4f46e5' : '#94a3b8', flexShrink: 0 }"
+                          size="small"
+                        >
+                          <template #icon><EnvironmentOutlined /></template>
+                        </a-avatar>
+                      </template>
+                      <template #title>
+                        <span class="loc-title">{{ item.title }}</span>
+                      </template>
+                      <template #description>
+                        <span class="loc-desc">{{ item.desc }}</span>
+                      </template>
+                    </a-list-item-meta>
+                    <template #actions>
+                      <a-tag :color="item.active ? 'green' : 'default'" style="font-size:11px">
+                        {{ item.active ? 'Active' : 'Off' }}
+                      </a-tag>
+                    </template>
+                  </a-list-item>
+                </template>
+              </a-list>
+            </a-card>
+          </a-col>
+
+          <!-- Selected detail -->
+          <a-col v-if="selected" :span="24">
+            <a-card :bordered="false" class="detail-card">
+              <template #title>
+                <div class="card-title-row">
+                  <InfoCircleOutlined class="card-title-icon" />
+                  <span>Selected Location</span>
+                </div>
+              </template>
+
+              <a-descriptions :column="1" size="small" :bordered="false">
+                <a-descriptions-item label="Name">{{ selected.title }}</a-descriptions-item>
+                <a-descriptions-item label="Description">{{ selected.desc }}</a-descriptions-item>
+                <a-descriptions-item label="Latitude">{{ selected.lat.toFixed(5) }}</a-descriptions-item>
+                <a-descriptions-item label="Longitude">{{ selected.lng.toFixed(5) }}</a-descriptions-item>
+                <a-descriptions-item label="Status">
+                  <a-tag :color="selected.active ? 'green' : 'default'">
+                    {{ selected.active ? 'Active' : 'Inactive' }}
+                  </a-tag>
+                </a-descriptions-item>
+              </a-descriptions>
+            </a-card>
+          </a-col>
+
+        </a-row>
+      </a-col>
+
+    </a-row>
+
+    <!-- Add location modal -->
+    <a-modal
+      v-model:open="showAddModal"
+      title="Add New Location"
+      ok-text="Add Marker"
+      @ok="submitAdd"
+      @cancel="resetForm"
+    >
+      <a-form :model="addForm" layout="vertical" style="margin-top:12px">
+        <a-form-item label="Title" required>
+          <a-input v-model:value="addForm.title" placeholder="Location name" />
+        </a-form-item>
+        <a-form-item label="Description">
+          <a-input v-model:value="addForm.desc" placeholder="Short description" />
+        </a-form-item>
+        <a-row :gutter="12">
+          <a-col :span="12">
+            <a-form-item label="Latitude" required>
+              <a-input-number
+                v-model:value="addForm.lat"
+                :precision="5"
+                :step="0.001"
+                style="width:100%"
+              />
+            </a-form-item>
+          </a-col>
+          <a-col :span="12">
+            <a-form-item label="Longitude" required>
+              <a-input-number
+                v-model:value="addForm.lng"
+                :precision="5"
+                :step="0.001"
+                style="width:100%"
+              />
+            </a-form-item>
+          </a-col>
+        </a-row>
+        <a-form-item label="Status">
+          <a-switch v-model:checked="addForm.active" checked-children="Active" un-checked-children="Inactive" />
+        </a-form-item>
+      </a-form>
+    </a-modal>
   </div>
 </template>
 
 <script setup>
-import L from 'leaflet';
-import 'leaflet/dist/leaflet.css';
-// NOSONAR
-// import 'leaflet-tracksymbol'
-// import '@/assets/leaflet.latlng-graticule'
+// biome-ignore lint/correctness/noUnusedImports: icons used in Vue template
+import { EnvironmentOutlined, InfoCircleOutlined, PlusOutlined, UnorderedListOutlined } from '@ant-design/icons-vue';
+import { reactive, ref } from 'vue';
+// biome-ignore lint/correctness/noUnusedImports: component used in Vue template
+import LeafletMap from '../../components/LeafletMap.vue';
 
-// stupid hack so that leaflet's images work after going through webpack
-// import marker from 'leaflet/dist/images/marker-icon.png'
-// import marker2x from 'leaflet/dist/images/marker-icon-2x.png'
-// import markerShadow from 'leaflet/dist/images/marker-shadow.png'
+const mapRef = ref(null);
+const tileLayer = ref('osm');
+const mapCenter = ref([51.505, -0.09]);
+const mapZoom = ref(12);
+const selectedId = ref(null);
+const selected = ref(null);
+const showAddModal = ref(false);
 
-import { onMounted } from 'vue';
+const tileLabels = { osm: 'OpenStreetMap', topo: 'Topographic', dark: 'Dark Mode' };
 
-onMounted(async () => {
-  const map = L.map('map').setView([51.505, -0.09], 13);
+const markers = reactive([
+  { id: 1, lat: 51.505, lng: -0.09, title: 'Central London', desc: 'City of Westminster', active: true },
+  { id: 2, lat: 51.515, lng: -0.072, title: 'Shoreditch', desc: 'Tech & creative hub', active: true },
+  { id: 3, lat: 51.495, lng: -0.135, title: 'Chelsea', desc: 'Royal Borough of Kensington', active: true },
+  { id: 4, lat: 51.532, lng: -0.106, title: 'Islington', desc: 'London Borough of Islington', active: false },
+  { id: 5, lat: 51.488, lng: -0.074, title: 'Bermondsey', desc: 'London Borough of Southwark', active: true },
+]);
 
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-  }).addTo(map);
+let nextId = markers.length + 1;
 
-  L.marker([51.5, -0.09]).addTo(map).bindPopup('A pretty CSS3 popup.<br> Easily customizable.').openPopup();
-});
+const addForm = reactive({ title: '', desc: '', lat: 51.505, lng: -0.09, active: true });
+
+const flyToMarker = item => {
+  selectedId.value = item.id;
+  selected.value = item;
+  mapRef.value?.flyTo(item.lat, item.lng, 14);
+};
+
+const onMarkerClick = item => {
+  selectedId.value = item.id;
+  selected.value = item;
+};
+
+const submitAdd = () => {
+  if (!addForm.title || !addForm.lat || !addForm.lng) return;
+  markers.push({
+    id: nextId++,
+    lat: addForm.lat,
+    lng: addForm.lng,
+    title: addForm.title,
+    desc: addForm.desc,
+    active: addForm.active,
+  });
+  resetForm();
+  showAddModal.value = false;
+};
+
+const resetForm = () => {
+  addForm.title = '';
+  addForm.desc = '';
+  addForm.lat = 51.505;
+  addForm.lng = -0.09;
+  addForm.active = true;
+};
 </script>
 
 <style scoped>
-.map {
-  /* top: 50px; */
+.demo-leaflet {
+  font-family: 'DM Sans', sans-serif;
+}
+
+.map-card,
+.location-card,
+.detail-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+:deep(.map-card .ant-card-head),
+:deep(.location-card .ant-card-head),
+:deep(.detail-card .ant-card-head) {
+  border-bottom: 1px solid #f1f5f9;
+  padding: 0 20px;
+  min-height: 48px;
+}
+
+:deep(.map-card .ant-card-body) {
+  padding: 0;
+  border-radius: 0 0 12px 12px;
+  overflow: hidden;
+}
+
+:deep(.location-card .ant-card-body),
+:deep(.detail-card .ant-card-body) {
+  padding: 8px 16px 16px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
   width: 100%;
-  /* calc(100vw -200px); */
-  /* height: calc(100vh - 50px); */
-  height: 100vh;
-  margin: auto;
-  z-index: 1;
+}
+
+.card-title-icon {
+  color: #4f46e5;
+  font-size: 15px;
+}
+
+.map-wrapper {
+  height: 480px;
+}
+
+/* Mini stat cards */
+.mini-stat-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+:deep(.mini-stat-card .ant-card-body) {
+  padding: 14px 16px;
+}
+
+:deep(.mini-stat-card .ant-statistic-title) {
+  font-size: 11px;
+  color: #64748b;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+/* Location list items */
+.location-item {
+  cursor: pointer;
+  border-radius: 8px;
+  padding: 8px 6px;
+  transition: background 0.15s;
+}
+
+.location-item:hover {
+  background: #f8fafc;
+}
+
+.location-item--active {
+  background: #eef2ff;
+}
+
+.loc-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.loc-desc {
+  font-size: 11px;
+  color: #64748b;
+}
+
+/* Descriptions */
+:deep(.detail-card .ant-descriptions-item-label) {
+  font-size: 12px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+:deep(.detail-card .ant-descriptions-item-content) {
+  font-size: 12px;
+  color: #1e293b;
 }
 </style>

--- a/apps/sample-vue-full/vite.config.js
+++ b/apps/sample-vue-full/vite.config.js
@@ -54,6 +54,7 @@ export default ({ command, mode }) => {
     server: {
       host: '127.0.0.1',
       port: 8080,
+      proxy: mode === 'development' ? { '/api': { target: 'http://127.0.0.1:3000', changeOrigin: true } } : {},
     },
   };
 };

--- a/common/vanilla/web/t4t-fe.js
+++ b/common/vanilla/web/t4t-fe.js
@@ -1,4 +1,4 @@
-import Fetch from './fetch.js';
+import Fetch from '../iso/fetch.js';
 
 let tableName = '';
 let parentFilter = null;


### PR DESCRIPTION
## Pull Request Checklist

- [x] I read and followed the [Contribution guide](https://github.com/ais-one/novex-kit/blob/main/.github/CONTRIBUTING.md)
- [ ] I linked the related issue, if one exists
- [x] I ran the relevant checks or tests for the affected area

## Summary

Redesign and improve the `sample-vue-full` frontend: fix broken imports, split the secure layout into reusable components, redesign the sign-in page and dashboard, add web component wrappers, refactor all Demo, Visuals, Data Entry, and T4t views with reusable ADV components, and fix Biome and SonarCloud issues.

**What is being improved and why:**

The existing `sample-vue-full` app had several issues that made it hard to use as a reference template: broken `@common/*` import paths that prevented Vite from starting, placeholder CSS that poisoned all text colors, a bare login page with no real layout, a dashboard made entirely of skeleton loaders, monolithic layout files with no component separation, and Demo/Visuals/DataEntry views with raw HTML elements and no Ant Design structure. These changes address all of that — the goal is for `sample-vue-full` to serve as a genuinely usable reference for teams starting new apps from this template.

**Changes by area:**

_Imports & build:_
- Fixed broken relative `../common/*` imports — replaced with proper `@common/vue`, `@common/iso`, `@common/web` package names
- Added explicit Vite `resolve.alias` for all `@common/*` packages to ensure reliable resolution regardless of npm workspace hoisting
- Added missing `VITE_INITIAL_SECURE_PATH` and `VITE_INITIAL_PUBLIC_PATH` env vars that caused silent login failure (`router.push(undefined)`)
- Fixed broken `./fetch.js` import in `common/vanilla/web/t4t-fe.js` — corrected to `../iso/fetch.js`
- Fixed broken `dev:mocked` script (`--config apps/vite.config.js` path didn't exist) — corrected to use local `vite.config.js`
- Added Vite dev server proxy (`/api` → `http://127.0.0.1:3000`) for `development` mode so T4t pages work without changing the API URL env var

_Fonts & styling:_
- Self-hosted `Fraunces` and `DM Sans` via `@fontsource` packages to eliminate Google Fonts CDN dependency and fix SonarCloud SRI warning
- Replaced placeholder `* { color: darkgreen }` global CSS with a proper reset
- Unified typography — replaced all `Fraunces` serif usage with `DM Sans` for a consistent, modern UI

_Sign-in page:_
- Replaced bare form with a split-panel layout: dark decorative left panel (animated dot grid, brand, stack pills) and clean white right panel
- Used `a-input`, `a-button`, `a-checkbox` from Ant Design Vue with `:deep()` overrides for consistent focus/hover styling
- Added slide transition between login and OTP modes

_Secure layout — split into reusable components:_
- `AppSidebar.vue` — dark navy sidebar, collapsible with `breakpoint="md"`, brand via props, `a-menu` navigation, mobile overlay with backdrop; all app-specific data injected via props
- `AppHeader.vue` — sticky header with `a-button` toggle, `a-input` search (toggle on click), `a-popover` + `a-list` for chat and notifications, `a-divider`, `a-avatar` + `a-dropdown` for user menu; data received via props, mutations emitted as events
- `AppFooter.vue` — minimal footer with `brand` prop

_Dashboard:_
- `StatCard.vue` (reusable) — `a-statistic` inside `a-card` with trend icon, footer text, hover lift animation; fully prop-driven
- `MemberCard.vue` (reusable) — `a-card` + `a-avatar` + `a-tag` with visible border and hover shadow
- Replaced skeleton loaders with real content: Comments (`a-list` + `a-typography-paragraph` with expandable ellipsis), Useful Links (`a-list` with icons), Announcements (`a-timeline` with type tags and unread badge)

_Web component wrappers:_
- `WebCamCapture.vue` (reusable) — wraps `vcxwc-web-cam` with `a-card`, live status indicator, snapshot grid with download/delete, snap log
- `SignaturePad.vue` (reusable) — wraps `vcxwc-sign-pad` with `a-card`, signed/empty tag, save and clear actions, preview via `a-image`; full `v-model` support and configurable stroke/background props

_Demo views — reusable components and ADV layout:_
- `ColorBox.vue` (reusable) — 80×80 colored box with hover lift animation, replaces inline-styled divs
- `DemoTest.vue` — reorganised into 4 `a-card` sections (Template Refs, Counter & Store, Object Reactivity, API & MSW Tests); raw `<button>` and `<div>` elements replaced with `a-button`, `a-tag`, `a-space`, `a-divider`; API response now displayed inline instead of `console.log` only
- `DemoSignPad.vue` — uses `SignaturePad.vue` reusable component with two instances (Full Signature and Initials), shared signature log via `a-list`
- `DemoWebCam.vue` — uses `WebCamCapture.vue` reusable component with snap log via `a-list`
- `Filler.vue` — redesigned with `a-card` wrapper, `a-descriptions` for route info, and responsive grid list (`a-list` + `a-card` grid) for 50-item scroll test

_Visuals views — reusable components and ADV layout:_
- `ChartCard.vue` (reusable) — wraps Chart.js canvas in `a-card` with title icon, `#extra` slot for controls (radio group, select), and reactive chart rebuild via `watch`
- `DemoChart1.vue` — redesigned with 4 `a-statistic` summary cards, bar chart with Q1–Q4 `a-radio-group` switcher, doughnut chart (category split), and line chart with year `a-select`; all icons passed through `markRaw` to satisfy Biome
- `LeafletMap.vue` (reusable) — wraps Leaflet with fix for Vite marker icon resolution (`L.Icon.Default.mergeOptions`), props for `center`, `zoom`, `markers[]`, and `tileLayer`; emits `map-click` and `marker-click`; exposes `flyTo` method via `defineExpose`
- `DemoLeaflet.vue` — redesigned with tile layer switcher (`a-radio-group`: Street / Topo / Dark), location list (`a-list` + `a-avatar` + `a-tag`), click-to-fly-to behavior, selected location detail via `a-descriptions`, and Add Location `a-modal` with form (`a-input`, `a-input-number`, `a-switch`)

_Data Entry views — ADV layout:_
- `DemoForm.vue` — redesigned with 2-column card-grid: Various Inputs card (slider, date-picker, switch, checkbox-group, radio-group, textarea, store counter) + Transfer card on the left; File Upload, WebSocket, and Error Pages cards on the right; all submit buttons have `:loading` state
- `DemoCard.vue` — full ADV card showcase across 7 sections: Basic Cards, Cover Cards (gradient CSS + `a-card-meta`), Statistic Cards, Tabbed Card (`a-tabs` + `a-list`), Inner Cards (`a-card type="inner"` + `a-progress`), Loading State (`a-skeleton` + `a-switch` toggle), and Quick Entry Form
- `DemoCascade.vue` — redesigned with 2-column layout: cascade form (Region multi-select → Countries multi-select) on the left; live Selection Summary (per-region breakdown with `a-badge` + `a-tag`) and Stats (`a-statistic` ×3) on the right
- `DemoCascade2.vue` — redesigned with 2-column layout: continent/country/state checkboxes with indeterminate support and Force Include/Exclude filters on the left; Stats card + `a-tree` selection hierarchy + Force Filters summary on the right; fixed typo `forceExlcudes` → `forceExcludes` and empty `onCheckAllChangeExcludes`
- `DemoCascade2Api.vue` — redesigned as API-driven version with per-section `a-spin` loading states, `a-badge` API status indicator, `a-alert` for errors, and `a-timeline` showing GET endpoint details

_T4t CRUD view:_
- `T4t.vue` — redesigned with `a-card` wrapper (table display name + record count badge in title), all toolbar actions (Reload, Filter, Create, Delete, Import, Export, Back) moved to `#extra` with proper ADV button types and icons; filter drawer uses `#footer` slot with Add Filter / Clear All / Apply; form drawer uses `#footer` slot with Cancel / Save Changes; `a-empty` shown when no filters added
- Fixed T4t route paths from flat depth-2 (`/t4t-student`) to grouped depth-3 (`/t4t/student`, `/t4t/subject`, `/t4t/audit-logs`) so they appear as a **T4t** submenu group in the sidebar
- Added MSW mock handlers for `GET /api/t4t/config/:table` and `GET /api/t4t/find/:table` — student (3 records), subject (4 records), audit_logs (2 records) — so the T4t pages work fully in `dev:mocked` mode without a backend

_Quality fixes:_
- Fixed Biome false-positive `noUnusedImports` warnings for Vue template imports — used `markRaw`/computed pattern where possible, `biome-ignore` for unavoidable cases
- Fixed SonarCloud contrast failures: replaced `rgba` hover backgrounds with solid equivalents so SonarCloud can compute contrast against the actual dark background; corrected text colors to meet WCAG AA 4.5:1
- Fixed SonarCloud nested template literal warning in `LeafletMap.vue` — extracted inner expression to a variable before use
- Fixed duplicate `.stat-icon-wrap` CSS selector

## Affected Area

- [x] apps
- [x] common
- [ ] docs
- [ ] scripts
- [ ] CI/CD or GitHub Actions

## Validation

```text
# Vite dev server starts cleanly
cd apps/sample-vue-full && npm run dev

# Biome — 0 errors, 0 warnings
npx biome check apps/sample-vue-full

# Manual checks
# 1. Open http://127.0.0.1:8080 — sign-in page renders correctly
# 2. Check "Force login (bypass backend)" → click Sign In → redirects to /dashboard
# 3. Sidebar collapses on mobile (< 768px), backdrop appears when opened
# 4. Notification and chat popovers open/close with correct unread counts
# 5. Stat card hover animation on /dashboard
# 6. WebCam capture at /demo/web-cam — take photo, verify snapshot grid
# 7. Signature pad at /demo/sign-pad — draw, verify preview and download
# 8. Chart page at /visuals/g2-chart1 — verify bar/doughnut/line charts render and Q1–Q4 / year switchers update data
# 9. Leaflet map at /visuals/leaflet-map — verify tile switcher, click location list to fly-to, add new marker via modal
# 10. Data Entry pages — /data-entry/form, /data-entry/card, /data-entry/cascade, /data-entry/cascade2
# 11. T4t pages — run `npm run dev:mocked`, open /t4t/student — table loads with mock data; verify T4t submenu group appears in sidebar
